### PR TITLE
Moonshots XXI allow for use in declarative sfdc

### DIFF
--- a/force-app/main/classes/DataStore.cls
+++ b/force-app/main/classes/DataStore.cls
@@ -1,20 +1,29 @@
 public class DataStore implements DataStoreInterface {
+  private Map<String, Map<String, VersionedData__c>> versionedDataMap;
+
   public DataStore() {
   }
 
-  public VersionedData__C getVersioned(String key, String kind) {
-    List<VersionedData__c> versioned = [
-      SELECT Version__c, Raw__c, Key__c, Kind__c
-      FROM VersionedData__c
-      WHERE Key__c = :key AND Kind__c = :kind
-      LIMIT 1
-    ];
-
-    if (versioned.isEmpty()) {
-      return null;
-    } else {
-      return versioned.get(0);
+  private void populateVersioned() {
+    // Preserve SOQL queries (each transaction only gets 100) by querying all data once
+    // Data can them be retrieved via the map structure in the event that multiple data are needed at different times
+    if (versionedDataMap == null) {
+      versionedDataMap = new Map<String, Map<String, VersionedData__c>>{
+        'flags' => new Map<String, VersionedData__c>(),
+        'segments' => new Map<String, VersionedData__c>()
+      };
+      for (VersionedData__c vd : [
+        SELECT Id, Version__c, Raw__c, Key__c, Kind__c
+        FROM VersionedData__c
+      ]) {
+        versionedDataMap.get(vd.Kind__c).put(vd.Key__c, vd);
+      }
     }
+  }
+
+  public VersionedData__c getVersioned(String key, String kind) {
+    populateVersioned();
+    return versionedDataMap.get(kind).get(key);
   }
 
   public DataModel.Flag getFlag(String key) {
@@ -38,15 +47,10 @@ public class DataStore implements DataStoreInterface {
   }
 
   public Map<String, DataModel.Flag> allFlags() {
+    populateVersioned();
     Map<String, DataModel.Flag> result = new Map<String, DataModel.Flag>();
 
-    List<VersionedData__c> flags = [
-      SELECT Version__c, Raw__c, Key__c, Kind__c
-      FROM VersionedData__c
-      WHERE Kind__c = 'flags'
-    ];
-
-    for (VersionedData__C flag : flags) {
+    for (VersionedData__C flag : versionedDataMap.get('flags').values()) {
       try {
         result.put(flag.Key__c, new DataModel.Flag(flag.Raw__c));
       } catch (Exception err) {
@@ -59,9 +63,15 @@ public class DataStore implements DataStoreInterface {
 
   public void putAll(Map<String, Object> kinds) {
     // delete existing store values
-    List<VersionedData__c> existingFeatures = [SELECT Key__c FROM VersionedData__C];
-    delete existingFeatures;
+    populateVersioned();
+    List<VersionedData__c> existingFeatures = new List<VersionedData__c>();
+    existingFeatures.addAll(versionedDataMap.get('flags').values());
+    existingFeatures.addAll(versionedDataMap.get('segments').values());
+    if (existingFeatures.size() > 0) {
+      delete existingFeatures;
+    }
     // iterate over kinds of features such as flags / segments
+    List<VersionedData__c> featureList = new List<VersionedData__c>();
     for (String kind : kinds.keySet()) {
       Map<String, Object> features = (Map<String, Object>) kinds.get(kind);
 
@@ -70,16 +80,14 @@ public class DataStore implements DataStoreInterface {
 
         VersionedData versioned = new VersionedData(kind, feature);
 
-        this.insertVersionedData(versioned);
+        featureList.add(versioned.getSObject());
       }
     }
-  }
-
-  public void insertVersionedData(VersionedData value) {
-    try {
-      insert value.getSObject();
-    } catch (Exception err) {
-      // required by compiler
+    if (featureList.size() > 0) {
+      insert featureList;
     }
+
+    // clear our versionedDataMap so that next time it is required it will be repopulated
+    versionedDataMap = null;
   }
 }

--- a/force-app/main/classes/EventSink.cls
+++ b/force-app/main/classes/EventSink.cls
@@ -1,10 +1,13 @@
 public class EventSink implements EventSinkInterface {
   Integer maxEvents;
+  private Integer eventsAddedCount;
+  private Integer existingEventsCount;
 
   public EventSink(Integer maxEvents) {
     System.assertNotEquals(maxEvents, null);
 
     this.maxEvents = maxEvents;
+    this.eventsAddedCount = 0;
   }
 
   public void sinkIdentify(LDEvent.Identify event) {
@@ -24,9 +27,12 @@ public class EventSink implements EventSinkInterface {
   }
 
   public void sinkGeneric(String kind, String raw) {
-    Integer count = [SELECT COUNT() FROM EventData__c];
-
-    if (count >= this.maxEvents) {
+    // Preserve SOQL queries (each transaction only gets 100) by getting count once and comparing to updated events count
+    if (existingEventsCount == null) {
+      existingEventsCount = [SELECT COUNT() FROM EventData__c];
+    }
+    // Only create event if threshold has not been met
+    if ((existingEventsCount + eventsAddedCount) >= this.maxEvents) {
       return;
     }
 
@@ -35,5 +41,6 @@ public class EventSink implements EventSinkInterface {
     record.Raw__c = raw;
 
     insert record;
+    eventsAddedCount++;
   }
 }

--- a/force-app/main/classes/LDClientInvocable.cls
+++ b/force-app/main/classes/LDClientInvocable.cls
@@ -5,14 +5,16 @@ public class LDClientInvocable {
     public String flagKey;
     @InvocableVariable(label='Flag Type' description='Flag Type corresponding to Flag Key. Valid options are: Boolean, Double, Integer, and String.' required=true)
     public String flagType;
-    @InvocableVariable(label='Boolean Fallback' description='Fallback for Boolean Flag type if no variation found from LaunchDarkly' required=false)
+    @InvocableVariable(label='Fallback (Boolean)' description='Fallback for Boolean Flag type if no variation found from LaunchDarkly' required=false)
     public Boolean booleanFallback;
-    @InvocableVariable(label='Double Fallback' description='Fallback for Double (Number) Flag type if no variation found from LaunchDarkly' required=false)
+    @InvocableVariable(label='Fallback (Double)' description='Fallback for Double (Number) Flag type if no variation found from LaunchDarkly' required=false)
     public Double doubleFallback;
-    @InvocableVariable(label='Integer Fallback' description='Fallback for Integer (Number) Flag type if no variation found from LaunchDarkly' required=false)
+    @InvocableVariable(label='Fallback (Integer)' description='Fallback for Integer (Number) Flag type if no variation found from LaunchDarkly' required=false)
     public Integer integerFallback;
-    @InvocableVariable(label='String Fallback' description='Fallback for String Flag type if no variation found from LaunchDarkly' required=false)
+    @InvocableVariable(label='Fallback (String)' description='Fallback for String Flag type if no variation found from LaunchDarkly' required=false)
     public String stringFallback;
+    @InvocableVariable(label='LaunchDarkly Client' description='If provided, the LD Client can be persisted across requests to preserve SOQL queries and DML statements' required=false)
+    public LDFlowClient ldClient_Flow;
     @InvocableVariable(label='User custom attributes' description='Key/Value pairs to assign to user context evaluation. Id and Name will be assigned automatically' required=false)
     public List<LDFlowMapKey> userCustomAttributes;
     @InvocableVariable(label='User to be Identified' description='If TRUE, the LDClient.identify method will be called' required=false)
@@ -20,33 +22,32 @@ public class LDClientInvocable {
   }
 
   public class InvocableResponse {
-    @InvocableVariable(label='Flag Key belonging to the Variation' description='' required=true)
-    public String flagKey;
-    @InvocableVariable(label='Flag Type' description='Flag Type corresponding to Flag Key' required=true)
-    public String flagType;
-    @InvocableVariable(label='Boolean Variation' description='Variation for Boolean Flag type' required=false)
+    @InvocableVariable(label='LaunchDarkly Client' description='Instance of LDClient used to retrieve the variation' required=false)
+    public LDFlowClient ldClient_Flow;
+    @InvocableVariable(label='Variation (Boolean)' description='Variation for Boolean Flag type' required=false)
     public Boolean booleanVariation;
-    @InvocableVariable(label='Double Variation' description='Variation for Double (Number) Flag type' required=false)
+    @InvocableVariable(label='Variation (Double)' description='Variation for Double (Number) Flag type' required=false)
     public Double doubleVariation;
-    @InvocableVariable(label='Integer Variation' description='Variation for Integer (Number) Flag type' required=false)
+    @InvocableVariable(label='Variation (Integer)' description='Variation for Integer (Number) Flag type' required=false)
     public Integer integerVariation;
-    @InvocableVariable(label='String Variation' description='Variation for String Flag type' required=false)
+    @InvocableVariable(label='Variation (String)' description='Variation for String Flag type' required=false)
     public String stringVariation;
 
     public InvocableResponse(InvocableRequest request) {
-      this.flagKey = request.flagKey;
-      this.flagType = request.flagType;
       this.booleanVariation = false;
     }
   }
 
-  @InvocableMethod(label='Get LaunchDarkly Variation' description='Returns the flag variation for a set of Flag keys')
+  @InvocableMethod(label='Get LaunchDarkly Variation' description='Returns the flag variation for a given of Flag Key')
   public static List<InvocableResponse> flagVariation(List<InvocableRequest> requests) {
-    LDClient client = new LDClient();
+    LDClient client = determineClient(requests);
+    LDFlowClient flowClient = new LDFlowClient();
+    flowClient.client = client;
     List<InvocableResponse> results = new List<InvocableResponse>();
     for (InvocableRequest request : requests) {
       LDUser user = buildLDUser(client, request);
       InvocableResponse result = new InvocableResponse(request);
+      result.ldClient_Flow = flowClient;
       if (request.flagType != null) {
         switch on request.flagType.toLowerCase() {
           when 'boolean' {
@@ -68,6 +69,23 @@ public class LDClientInvocable {
       results.add(result);
     }
     return results;
+  }
+
+  private static LDClient determineClient(List<InvocableRequest> requests) {
+    LDClient client;
+    for (InvocableRequest request : requests) {
+      if (client != null) {
+        break;
+      }
+      if (request.ldClient_Flow != null) {
+        client = request.ldClient_Flow.client;
+      }
+    }
+    if (client == null) {
+      client = new LDClient();
+    }
+
+    return client;
   }
 
   private static LDUser buildLDUser(LDClient client, InvocableRequest request) {

--- a/force-app/main/classes/LDClientInvocable.cls
+++ b/force-app/main/classes/LDClientInvocable.cls
@@ -1,0 +1,116 @@
+public class LDClientInvocable {
+
+  public class InvocableRequest {
+    @InvocableVariable(label='Flag Key' description='Flag Key as defined in LaunchDarkly' required=true)
+    public String flagKey;
+    @InvocableVariable(label='Flag Type' description='Flag Type corresponding to Flag Key. Valid options are: Boolean, Double, Integer, and String.' required=true)
+    public String flagType;
+    @InvocableVariable(label='Boolean Fallback' description='Fallback for Boolean Flag type if no variation found from LaunchDarkly' required=false)
+    public Boolean booleanFallback;
+    @InvocableVariable(label='Double Fallback' description='Fallback for Double (Number) Flag type if no variation found from LaunchDarkly' required=false)
+    public Double doubleFallback;
+    @InvocableVariable(label='Integer Fallback' description='Fallback for Integer (Number) Flag type if no variation found from LaunchDarkly' required=false)
+    public Integer integerFallback;
+    @InvocableVariable(label='String Fallback' description='Fallback for String Flag type if no variation found from LaunchDarkly' required=false)
+    public String stringFallback;
+    @InvocableVariable(label='User custom attributes' description='Key/Value pairs to assign to user context evaluation. Id and Name will be assigned automatically' required=false)
+    public List<LDFlowMapKey> userCustomAttributes;
+    @InvocableVariable(label='User to be Identified' description='If TRUE, the LDClient.identify method will be called' required=false)
+    public Boolean userToBeIdentified;
+  }
+
+  public class InvocableResponse {
+    @InvocableVariable(label='Flag Key belonging to the Variation' description='' required=true)
+    public String flagKey;
+    @InvocableVariable(label='Flag Type' description='Flag Type corresponding to Flag Key' required=true)
+    public String flagType;
+    @InvocableVariable(label='Boolean Variation' description='Variation for Boolean Flag type' required=false)
+    public Boolean booleanVariation;
+    @InvocableVariable(label='Double Variation' description='Variation for Double (Number) Flag type' required=false)
+    public Double doubleVariation;
+    @InvocableVariable(label='Integer Variation' description='Variation for Integer (Number) Flag type' required=false)
+    public Integer integerVariation;
+    @InvocableVariable(label='String Variation' description='Variation for String Flag type' required=false)
+    public String stringVariation;
+
+    public InvocableResponse(InvocableRequest request) {
+      this.flagKey = request.flagKey;
+      this.flagType = request.flagType;
+      this.booleanVariation = false;
+    }
+  }
+
+  @InvocableMethod(label='Get LaunchDarkly Variation' description='Returns the flag variation for a set of Flag keys')
+  public static List<InvocableResponse> flagVariation(List<InvocableRequest> requests) {
+    LDClient client = new LDClient();
+    List<InvocableResponse> results = new List<InvocableResponse>();
+    for (InvocableRequest request : requests) {
+      LDUser user = buildLDUser(client, request);
+      InvocableResponse result = new InvocableResponse(request);
+      if (request.flagType != null) {
+        switch on request.flagType.toLowerCase() {
+          when 'boolean' {
+            result.booleanVariation = client.boolVariation(user, request.flagKey, request.booleanFallback != null ? request.booleanFallback : false);
+          }
+          when 'double' {
+            result.doubleVariation = client.doubleVariation(user, request.flagKey, request.doubleFallback);
+          }
+          when 'integer' {
+            result.integerVariation = client.intVariation(user, request.flagKey, request.integerFallback);
+          }
+          when 'string' {
+            result.stringVariation = client.stringVariation(user, request.flagKey, request.stringFallback);
+          }
+          when else {
+          }
+        }
+      }
+      results.add(result);
+    }
+    return results;
+  }
+
+  private static LDUser buildLDUser(LDClient client, InvocableRequest request) {
+    Map<String, LDValue>  valueObjectMap = new Map<String, LDValue>();
+    if (request.userCustomAttributes != null) {
+      for (LDFlowMapKey userAttribute : request.userCustomAttributes) {
+        if (userAttribute.valueType != null) {
+          switch on userAttribute.valueType.toLowerCase() {
+            when 'boolean' {
+              if (userAttribute.booleanValue != null) {
+                valueObjectMap.put(userAttribute.key, LDValue.of(userAttribute.booleanValue));
+              }
+            }
+            when 'double' {
+              if (userAttribute.doubleValue != null) {
+                valueObjectMap.put(userAttribute.key, LDValue.of(userAttribute.doubleValue));
+              }
+            }
+            when 'integer' {
+              if (userAttribute.integerValue != null) {
+                valueObjectMap.put(userAttribute.key, LDValue.of(userAttribute.integerValue));
+              }
+            }
+            when 'string' {
+              if (userAttribute.stringValue != null) {
+                valueObjectMap.put(userAttribute.key, LDValue.of(userAttribute.stringValue));
+              }
+            }
+            when else {
+            }
+          }
+        }
+      }
+    }
+    LDUser user = new LDUser.Builder(System.UserInfo.getUserId())
+      .setName(System.UserInfo.getName())
+      .setCustom(LDValueObject.fromMap(valueObjectMap))
+      .build();
+
+    if (request.userToBeIdentified == true) {
+      client.identify(user);
+    }
+
+    return user;
+  }
+}

--- a/force-app/main/classes/LDClientInvocable.cls-meta.xml
+++ b/force-app/main/classes/LDClientInvocable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="OrderController">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/classes/LDFlowClient.cls
+++ b/force-app/main/classes/LDFlowClient.cls
@@ -1,0 +1,10 @@
+// Used as an Apex-Defined Variable to allow LDClient persistance across variation calls
+public class LDFlowClient {
+  @AuraEnabled
+  public LDClient client;
+  // clientName only included so that LDFlowClient is visible as an Apex-Defined Variable in the Flow
+  @AuraEnabled
+  public String clientName;
+  
+  public LDFlowClient(){}
+}

--- a/force-app/main/classes/LDFlowClient.cls-meta.xml
+++ b/force-app/main/classes/LDFlowClient.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="OrderController">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/classes/LDFlowMapKey.cls
+++ b/force-app/main/classes/LDFlowMapKey.cls
@@ -1,3 +1,4 @@
+// Used as an Apex-Defined Variable to allow map-like entry for user custom attributes
 public class LDFlowMapKey {
   @AuraEnabled
   public string key;

--- a/force-app/main/classes/LDFlowMapKey.cls
+++ b/force-app/main/classes/LDFlowMapKey.cls
@@ -1,0 +1,16 @@
+public class LDFlowMapKey {
+  @AuraEnabled
+  public string key;
+  @AuraEnabled
+  public string valueType;
+  @AuraEnabled
+  public Boolean booleanValue;
+  @AuraEnabled
+  public Double doubleValue;
+  @AuraEnabled
+  public Integer integerValue;
+  @AuraEnabled
+  public string stringValue;
+  
+  public LDFlowMapKey(){}
+}

--- a/force-app/main/classes/LDFlowMapKey.cls-meta.xml
+++ b/force-app/main/classes/LDFlowMapKey.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="OrderController">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/test/LDClientInvocableTest.cls
+++ b/force-app/test/LDClientInvocableTest.cls
@@ -1,0 +1,93 @@
+@isTest
+private class LDClientInvocableTest {
+
+  @isTest
+  static void basicVariation() {
+    LDClientInvocable.InvocableRequest requestData = new LDClientInvocable.InvocableRequest();
+    requestData.flagKey = 'fakeFlag';
+    requestData.flagType = 'Boolean';
+    requestData.booleanFallback = false;
+    requestData.userCustomAttributes = new List<LDFlowMapKey>();
+
+    LDFlowMapKey booleanMapKey = new LDFlowMapKey();
+    booleanMapKey.key = 'booleanKey';
+    booleanMapKey.valueType = 'Boolean';
+    booleanMapKey.booleanValue = false;
+    requestData.userCustomAttributes.add(booleanMapKey);
+
+    LDFlowMapKey doubleMapKey = new LDFlowMapKey();
+    doubleMapKey.key = 'doubleKey';
+    doubleMapKey.valueType = 'Double';
+    doubleMapKey.doubleValue = 25.48;
+    requestData.userCustomAttributes.add(doubleMapKey);
+
+    LDFlowMapKey integerMapKey = new LDFlowMapKey();
+    integerMapKey.key = 'integerKey';
+    integerMapKey.valueType = 'Integer';
+    integerMapKey.integerValue = 25;
+    requestData.userCustomAttributes.add(integerMapKey);
+
+    LDFlowMapKey stringMapKey = new LDFlowMapKey();
+    stringMapKey.key = 'stringKey';
+    stringMapKey.valueType = 'String';
+    stringMapKey.stringValue = 'string';
+    requestData.userCustomAttributes.add(stringMapKey);
+
+    requestData.userToBeIdentified = true;
+
+    LDClientInvocable.InvocableResponse responseData = LDClientInvocable.flagVariation(new List<LDClientInvocable.InvocableRequest>{requestData})[0];
+
+    System.assertEquals(requestData.flagKey, responseData.flagKey, 'Response flag key should match the request flag key');
+    System.assertEquals(requestData.flagType, responseData.flagType, 'Response flag key should match the request flag key');
+    System.assertEquals(false, responseData.booleanVariation, 'Response Boolean Variation should be FALSE to match the fallback value since the flag does not exist');
+  }
+
+
+  @isTest
+  static void intVariation() {
+    LDClientInvocable.InvocableRequest requestData = new LDClientInvocable.InvocableRequest();
+    requestData.flagKey = 'fakeFlag';
+    requestData.flagType = 'Integer';
+    requestData.integerFallback = 2024;
+    requestData.userCustomAttributes = new List<LDFlowMapKey>();
+    requestData.userToBeIdentified = true;
+
+    LDClientInvocable.InvocableResponse responseData = LDClientInvocable.flagVariation(new List<LDClientInvocable.InvocableRequest>{requestData})[0];
+
+    System.assertEquals(requestData.flagKey, responseData.flagKey, 'Response flag key should match the request flag key');
+    System.assertEquals(requestData.flagType, responseData.flagType, 'Response flag key should match the request flag key');
+    System.assertEquals(2024, responseData.integerVariation, 'Response Integer Variation should be 2024 to match the fallback value since the flag does not exist');
+  }
+
+  @isTest
+  static void doubleVariation() {
+    LDClientInvocable.InvocableRequest requestData = new LDClientInvocable.InvocableRequest();
+    requestData.flagKey = 'fakeFlag';
+    requestData.flagType = 'Double';
+    requestData.doubleFallback = 2024.06;
+    requestData.userCustomAttributes = new List<LDFlowMapKey>();
+    requestData.userToBeIdentified = true;
+
+    LDClientInvocable.InvocableResponse responseData = LDClientInvocable.flagVariation(new List<LDClientInvocable.InvocableRequest>{requestData})[0];
+
+    System.assertEquals(requestData.flagKey, responseData.flagKey, 'Response flag key should match the request flag key');
+    System.assertEquals(requestData.flagType, responseData.flagType, 'Response flag key should match the request flag key');
+    System.assertEquals(2024.06, responseData.doubleVariation, 'Response Double Variation should be 2024.06 to match the fallback value since the flag does not exist');
+  }
+
+  @isTest
+  static void stringVariation() {
+    LDClientInvocable.InvocableRequest requestData = new LDClientInvocable.InvocableRequest();
+    requestData.flagKey = 'fakeFlag';
+    requestData.flagType = 'String';
+    requestData.stringFallback = 'test string';
+    requestData.userCustomAttributes = new List<LDFlowMapKey>();
+    requestData.userToBeIdentified = true;
+
+    LDClientInvocable.InvocableResponse responseData = LDClientInvocable.flagVariation(new List<LDClientInvocable.InvocableRequest>{requestData})[0];
+
+    System.assertEquals(requestData.flagKey, responseData.flagKey, 'Response flag key should match the request flag key');
+    System.assertEquals(requestData.flagType, responseData.flagType, 'Response flag key should match the request flag key');
+    System.assertEquals('test string', responseData.stringVariation, 'Response String Variation should be \'test string\' to match the fallback value since the flag does not exist');
+  }
+}

--- a/force-app/test/LDClientInvocableTest.cls
+++ b/force-app/test/LDClientInvocableTest.cls
@@ -37,8 +37,6 @@ private class LDClientInvocableTest {
 
     LDClientInvocable.InvocableResponse responseData = LDClientInvocable.flagVariation(new List<LDClientInvocable.InvocableRequest>{requestData})[0];
 
-    System.assertEquals(requestData.flagKey, responseData.flagKey, 'Response flag key should match the request flag key');
-    System.assertEquals(requestData.flagType, responseData.flagType, 'Response flag key should match the request flag key');
     System.assertEquals(false, responseData.booleanVariation, 'Response Boolean Variation should be FALSE to match the fallback value since the flag does not exist');
   }
 
@@ -54,8 +52,6 @@ private class LDClientInvocableTest {
 
     LDClientInvocable.InvocableResponse responseData = LDClientInvocable.flagVariation(new List<LDClientInvocable.InvocableRequest>{requestData})[0];
 
-    System.assertEquals(requestData.flagKey, responseData.flagKey, 'Response flag key should match the request flag key');
-    System.assertEquals(requestData.flagType, responseData.flagType, 'Response flag key should match the request flag key');
     System.assertEquals(2024, responseData.integerVariation, 'Response Integer Variation should be 2024 to match the fallback value since the flag does not exist');
   }
 
@@ -70,8 +66,6 @@ private class LDClientInvocableTest {
 
     LDClientInvocable.InvocableResponse responseData = LDClientInvocable.flagVariation(new List<LDClientInvocable.InvocableRequest>{requestData})[0];
 
-    System.assertEquals(requestData.flagKey, responseData.flagKey, 'Response flag key should match the request flag key');
-    System.assertEquals(requestData.flagType, responseData.flagType, 'Response flag key should match the request flag key');
     System.assertEquals(2024.06, responseData.doubleVariation, 'Response Double Variation should be 2024.06 to match the fallback value since the flag does not exist');
   }
 
@@ -86,8 +80,6 @@ private class LDClientInvocableTest {
 
     LDClientInvocable.InvocableResponse responseData = LDClientInvocable.flagVariation(new List<LDClientInvocable.InvocableRequest>{requestData})[0];
 
-    System.assertEquals(requestData.flagKey, responseData.flagKey, 'Response flag key should match the request flag key');
-    System.assertEquals(requestData.flagType, responseData.flagType, 'Response flag key should match the request flag key');
     System.assertEquals('test string', responseData.stringVariation, 'Response String Variation should be \'test string\' to match the fallback value since the flag does not exist');
   }
 }

--- a/force-app/test/LDClientInvocableTest.cls-meta.xml
+++ b/force-app/test/LDClientInvocableTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="OrderController">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Extending SDK functionality to declaritive SFDC via Flows. Also adjusting SOQL queries and DML statements to limit their occurance to minimize impact on SFDC Governor Limit breaches.

**Describe alternatives you've considered**

No other way to get Apex SDK into SFDC Flows. Adjusted SOQL queries / DML statements because every call to get a flag variation was consuming 2 SOQL queries. Most SFDC orgs are close to those limits so even consuming 2 SOQL queries in a transaction can be problematic.

**Additional context**

This was done for Moonshots XXI.

SFDC Flows are the main declarative automation for SFDC. It can only reference Apex code methods annotated with @InvocableMethod. However, only 1 @InvocableMethod can be included in an Apex class. As such, I only implemented the `LDClientInvocable.flagVariation` method that retrieves a single flag variation. In order to access other `LDClient` methods such as `allFlags`, the `LDClientInvocable.flagVariation` method would have to be augmented or another class/method would have to be created. That being said, SFDC Flows do not handle Map structures very well. So, a method such as `allFlags` is unlikely to provide more benefit than just retrieving a number of flags individually via the `LDClientInvocable.flagVariation` method (and passing in the`ldClient_Flow` attribute to conserve SOQL queries).

It should be noted that I also have built a base Apex class file that showcases how to access the LD Apex SDK via SFDC's Omnistudio as an Apex Remote Action. I have omitted that class here since Omnistudio is a paid add-on and it can only be included in the package if Omnistudio exists in the SFDC org. See https://docs.google.com/document/d/1xO-JjPDTmHmulZXEpXXQUzFtVCJetnKUpiNYR--lUDI/edit?usp=sharing.

SFDC Governor Limits reference: https://developer.salesforce.com/docs/atlas.en-us.salesforce_app_limits_cheatsheet.meta/salesforce_app_limits_cheatsheet/salesforce_app_limits_platform_apexgov.htm
