### PR TITLE
chore: Change name to owned namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "launchdarkly-apex-server-sdk",
+  "name": "@launchdarkly/apex-server-sdk",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "launchdarkly-apex-server-sdk",
+      "name": "@launchdarkly/apex-server-sdk",
       "version": "1.0.0",
       "devDependencies": {
         "prettier": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "launchdarkly-apex-server-sdk",
+  "name": "@launchdarkly/apex-server-sdk",
   "version": "1.0.0",
   "description": "LaunchDarkly Apex SDK",
   "homepage": "",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change; it updates the npm package name (including the lockfile) without touching runtime code or dependencies.
> 
> **Overview**
> Renames the npm package from `launchdarkly-apex-server-sdk` to the scoped `@launchdarkly/apex-server-sdk` in both `package.json` and `package-lock.json` so the project publishes/identifies under the owned namespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5de2a880260b1be334ef8e9432317a23c09999d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->