### PR TITLE
feat: add X-LaunchDarkly-Instance-Id header (SDK-2352)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,8 @@ jobs:
         run: |
           cd bridge
           go build .
+
+      - name: Test
+        run: |
+          cd bridge
+          go test ./...

--- a/bridge/go.mod
+++ b/bridge/go.mod
@@ -1,3 +1,5 @@
 module github.com/launchdarkly/apex-server-sdk/bridge
 
 go 1.13
+
+require github.com/google/uuid v1.3.1

--- a/bridge/go.sum
+++ b/bridge/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -31,6 +33,12 @@ const (
 	SDK_VERSION   = "1.4.1" // x-release-please-version
 	USER_AGENT    = "ApexServerClient/" + SDK_VERSION
 	HTTP_TIMEOUT  = 30 * time.Second
+	// INSTANCE_ID_HEADER is the HTTP header used to identify this bridge instance for
+	// estimating server-connection-minutes when polling LaunchDarkly. Its value is a
+	// v4 UUID generated once per bridge process and constant for that process's lifetime.
+	//
+	// See: sdk-specs / SCMP-server-connection-minutes-polling (section 1.1).
+	INSTANCE_ID_HEADER = "X-LaunchDarkly-Instance-Id"
 )
 
 type Bridge struct {
@@ -46,9 +54,13 @@ type Bridge struct {
 	oauthCurrentToken     string
 	oauthJWTKey           *rsa.PrivateKey
 	oauthURI              url.URL
-	lock                  sync.Mutex
-	context               context.Context
-	cancel                context.CancelFunc
+	// instanceID is a v4 UUID generated once per bridge process. It is sent on every
+	// LaunchDarkly-bound request (see INSTANCE_ID_HEADER) so the platform can estimate
+	// server-connection-minutes for polling clients.
+	instanceID string
+	lock       sync.Mutex
+	context    context.Context
+	cancel     context.CancelFunc
 }
 
 func newBridge() (*Bridge, error) {
@@ -144,6 +156,11 @@ func newBridge() (*Bridge, error) {
 	context, cancel := context.WithCancel(context.Background())
 	bridge.context = context
 	bridge.cancel = cancel
+
+	// Generate a stable v4 UUID once per bridge instance. This identifier travels on
+	// every LaunchDarkly-bound request via INSTANCE_ID_HEADER for the lifetime of the
+	// process, per the SCMP-server-connection-minutes-polling spec.
+	bridge.instanceID = uuid.New().String()
 
 	return &bridge, nil
 }
@@ -312,6 +329,9 @@ func (bridge *Bridge) eventLoop() error {
 			pushRequest.Header.Set("X-LaunchDarkly-Event-Schema", "3")
 			pushRequest.Header.Set("Authorization", bridge.launchDarklyKey)
 			pushRequest.Header.Set("User-Agent", USER_AGENT)
+			// Sent on every LaunchDarkly-bound request (matches the reference Go SDK,
+			// where DefaultHeaders carries the instance id across poll/stream/events).
+			pushRequest.Header.Set(INSTANCE_ID_HEADER, bridge.instanceID)
 
 			log.Print("pushing events to: " + pushURI)
 
@@ -356,6 +376,7 @@ func (bridge *Bridge) featureLoop() error {
 
 		pollRequest.Header.Set("Authorization", bridge.launchDarklyKey)
 		pollRequest.Header.Set("User-Agent", USER_AGENT)
+		pollRequest.Header.Set(INSTANCE_ID_HEADER, bridge.instanceID)
 
 		if etag != "" {
 			pollRequest.Header.Set("If-None-Match", etag)

--- a/bridge/main_test.go
+++ b/bridge/main_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// newTestBridge constructs a Bridge with just enough state to drive the polling
+// and event-push code paths in tests without performing real Salesforce / OAuth
+// setup. We intentionally avoid calling newBridge() because that path requires a
+// pile of environment variables and an RSA key.
+func newTestBridge(t *testing.T, baseURI, eventsURI string) *Bridge {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &Bridge{
+		client:                http.Client{},
+		salesforceURL:         "http://salesforce.invalid/",
+		launchDarklyKey:       "fake-sdk-key",
+		launchDarklyBaseURI:   baseURI,
+		launchDarklyEventsURI: eventsURI,
+		instanceID:            uuid.New().String(),
+		context:               ctx,
+		cancel:                cancel,
+	}
+}
+
+// TestInstanceIDIsValidUUIDv4 asserts that newBridge generates a parseable v4
+// UUID, satisfying SCMP requirement 1.1.2.
+func TestInstanceIDIsValidUUIDv4(t *testing.T) {
+	// We can't call newBridge() here because of its env-var requirements, so
+	// reproduce its UUID generation directly. This guards against an accidental
+	// regression where someone swaps in a non-v4 generator.
+	id := uuid.New()
+	parsed, err := uuid.Parse(id.String())
+	if err != nil {
+		t.Fatalf("generated instance id %q is not parseable: %v", id, err)
+	}
+	if parsed.Version() != 4 {
+		t.Fatalf("instance id must be UUID v4, got version %d", parsed.Version())
+	}
+}
+
+// TestPollRequestCarriesInstanceIDHeader satisfies requirement 1.1.1: the
+// header MUST be present on every polling request to LaunchDarkly.
+func TestPollRequestCarriesInstanceIDHeader(t *testing.T) {
+	var captured string
+	var cancel context.CancelFunc
+
+	ldServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get(INSTANCE_ID_HEADER)
+		cancel()
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer ldServer.Close()
+
+	bridge := newTestBridge(t, ldServer.URL, ldServer.URL)
+	cancel = bridge.cancel
+
+	if err := bridge.featureLoop(); err != nil {
+		t.Fatalf("featureLoop returned unexpected error: %v", err)
+	}
+	if captured == "" {
+		t.Fatal("poll request did not carry " + INSTANCE_ID_HEADER + " header")
+	}
+	if captured != bridge.instanceID {
+		t.Errorf("poll request instance id = %q, want %q", captured, bridge.instanceID)
+	}
+	parsed, err := uuid.Parse(captured)
+	if err != nil {
+		t.Fatalf("poll request instance id %q is not a parseable UUID: %v", captured, err)
+	}
+	if parsed.Version() != 4 {
+		t.Errorf("poll request instance id is not UUID v4 (version %d)", parsed.Version())
+	}
+}
+
+// TestEventPushCarriesInstanceIDHeader ensures the same per-instance GUID also
+// rides outbound event submissions, matching the reference Go SDK's behavior
+// of placing the header on the shared DefaultHeaders so all LD-bound traffic
+// inherits it.
+func TestEventPushCarriesInstanceIDHeader(t *testing.T) {
+	var capturedPushHeader string
+	var pushed bool
+	var cancel context.CancelFunc
+
+	// Salesforce mock returns a non-empty event payload so eventLoop proceeds
+	// to push to LaunchDarkly.
+	sfServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Stub OAuth: any request gets a 200 with a non-empty event array body.
+		if strings.Contains(r.URL.Path, "event") {
+			_, _ = w.Write([]byte(`[{"kind":"identify"}]`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sfServer.Close()
+
+	ldEventsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPushHeader = r.Header.Get(INSTANCE_ID_HEADER)
+		pushed = true
+		cancel()
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ldEventsServer.Close()
+
+	bridge := newTestBridge(t, "http://unused.invalid", ldEventsServer.URL)
+	bridge.salesforceURL = sfServer.URL + "/"
+	cancel = bridge.cancel
+	// Pre-seed an oauth token so requestWithOauth doesn't try to re-auth.
+	bridge.oauthCurrentToken = "test-token"
+
+	if err := bridge.eventLoop(); err != nil {
+		t.Fatalf("eventLoop returned unexpected error: %v", err)
+	}
+	if !pushed {
+		t.Fatal("eventLoop did not push events to LaunchDarkly")
+	}
+	if capturedPushHeader != bridge.instanceID {
+		t.Errorf("event push instance id = %q, want %q", capturedPushHeader, bridge.instanceID)
+	}
+}
+
+// TestInstanceIDsAreUniquePerInstance covers the spec implication that
+// different bridge instances generate different GUIDs.
+func TestInstanceIDsAreUniquePerInstance(t *testing.T) {
+	a := newTestBridge(t, "http://unused.invalid", "http://unused.invalid")
+	b := newTestBridge(t, "http://unused.invalid", "http://unused.invalid")
+	if a.instanceID == "" || b.instanceID == "" {
+		t.Fatal("instance ids must be non-empty")
+	}
+	if a.instanceID == b.instanceID {
+		t.Errorf("expected distinct instance ids across bridges, both were %q", a.instanceID)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `X-LaunchDarkly-Instance-Id` header to LaunchDarkly-bound HTTP requests (poll `/sdk/latest-all` and event push `/bulk`) from the Go bridge daemon. Value is a v4 UUID generated once per bridge process and stable for that process's lifetime.

Note: the Apex SDK is split between Apex code (Salesforce runtime, no outbound HTTP to LaunchDarkly) and a Go bridge daemon (handles all LD-bound HTTP). The header lives in the Go bridge accordingly.

## Test plan

- [x] \`go build\`, \`gofmt -l\`, \`go vet\`, \`go test -v -race ./...\` — all clean, 4/4 new tests pass
- [x] CI workflow updated to run \`go test ./...\` (previously only \`go build\`)
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to adding a new header on outbound LaunchDarkly requests plus accompanying tests/CI, with no changes to auth or request semantics beyond extra metadata.
> 
> **Overview**
> Adds a per-process UUIDv4 `X-LaunchDarkly-Instance-Id` header to all LaunchDarkly-bound HTTP calls from the Go bridge (flag polling and event bulk push) to support server-connection-minutes estimation.
> 
> Generates and stores the instance ID once at bridge startup, adds `github.com/google/uuid`, and introduces unit tests plus a CI update to run `go test ./...` for the bridge job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653e8ec20656fb867c8188b7526813b648c14aff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->