### PR TITLE
chore: modernize Salesforce CLI commands in Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
-      - name: Install Salesforce CLI (sfdx)
+      - name: Install Salesforce CLI (sf)
         run: npm install @salesforce/cli --global
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 SCRATCH_ORG=launchdarklyapexserversdk@example.com
 
 push:
-	sfdx force:source:push --forceoverwrite -u $(SCRATCH_ORG)
+	sf project deploy start --ignore-conflicts --target-org $(SCRATCH_ORG)
 
 test:
-	sfdx force:apex:test:run --synchronous -u $(SCRATCH_ORG)
+	sf apex run test --synchronous --target-org $(SCRATCH_ORG)
 
 orgdelete:
-	sfdx force:org:delete -u $(SCRATCH_ORG)
+	sf org delete scratch --no-prompt --target-org $(SCRATCH_ORG)
 
 orgcreate:
-	sfdx force:org:create -f config/project-scratch-def.json -a $(SCRATCH_ORG)
+	sf org create scratch --definition-file config/project-scratch-def.json --alias $(SCRATCH_ORG)


### PR DESCRIPTION
**Related issues**

Follow-up to launchdarkly/hello-apex-server#7 (same `sfdx force:*` → `sf` modernization). The Apex SDK's `Makefile` still used the deprecated `sfdx force:*` commands, which are removed from the current Salesforce CLI (`sf` v2).

**Describe the solution you've provided**

Updated the `Makefile` targets to the current `sf` equivalents (flag names verified against the installed `@salesforce/cli` v2 and cross-checked with the official [sfdx → sf command mapping](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_move_to_sf_command_mapping.htm)):

| Old (`sfdx`) | New (`sf`) |
|---|---|
| `force:source:push --forceoverwrite -u <org>` | `project deploy start --ignore-conflicts --target-org <org>` |
| `force:apex:test:run --synchronous -u <org>` | `apex run test --synchronous --target-org <org>` |
| `force:org:delete -u <org>` | `org delete scratch --no-prompt --target-org <org>` |
| `force:org:create -f <file> -a <org>` | `org create scratch --definition-file <file> --alias <org>` |

Also renamed the CI step label `Install Salesforce CLI (sfdx)` → `(sf)` for accuracy. The CI workflow's actual commands already use `sf` and are unchanged.

**Describe alternatives you've considered**

N/A — the `force:*` topics no longer exist in the `sf` CLI, so these are the direct replacements.

**Additional context**

Docs/build-config only; no SDK/application code changed (`chore:`, non-releasable). The `--no-prompt` flag was added to `org delete scratch` to preserve the non-interactive behavior the Makefile relied on (`force:org:delete` did not prompt).

Link to Devin session: https://app.devin.ai/sessions/8148ac8939db4960ab05f5ce5b6e061d
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and local automation only; no SDK or runtime code changes, with behavior intended to match the prior Makefile flows.
> 
> **Overview**
> Replaces deprecated **`sfdx force:*`** invocations in the **`Makefile`** with current **`sf`** CLI equivalents so local scratch-org workflows (`push`, `test`, `orgdelete`, `orgcreate`) work with Salesforce CLI v2.
> 
> **`push`** now uses **`sf project deploy start --ignore-conflicts`**, tests use **`sf apex run test`**, and scratch org lifecycle commands use **`sf org delete scratch`** (with **`--no-prompt`** for non-interactive deletes) and **`sf org create scratch`**, with flags updated from **`-u`/`-f`/`-a`** to **`--target-org`**, **`--definition-file`**, and **`--alias`**.
> 
> The CI workflow step label is renamed from **Install Salesforce CLI (sfdx)** to **(sf)**; install and job steps already used **`sf`** and are otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684ef81a075fa5eddcfc09787195218ae6c03cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->