### PR TITLE
feat: Add configurable event and flag poll intervals to the bridge

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -37,4 +37,78 @@ export OAUTH_URI='YOUR OAUTH URI'
 export HTTP_TIMEOUT='Your timeout'
 # such as: '1500ms'
 # see https://golang.org/pkg/time/#ParseDuration for formatting
+export EVENT_POLL_INTERVAL='How often to drain events from Salesforce'
+# such as: '10s'
+# if not set, unparseable, zero, or negative, defaults to: '30s'
+# anything under '5s' is honored but logs a warning about org-wide API limits
+export FLAG_POLL_INTERVAL='How often to poll LaunchDarkly for flag data'
+# such as: '5m'
+# if not set or unparseable, defaults to: '30s'
+# minimum is '30s'; anything shorter is clamped up to '30s'
 ```
+
+## Polling intervals
+
+The daemon runs two independent loops, each on its own interval:
+
+| Loop | What it does | Variable | Default | Minimum |
+| --- | --- | --- | --- | --- |
+| Events | Drains `EventData__c` from Salesforce, then posts to LaunchDarkly | `EVENT_POLL_INTERVAL` | `30s` | greater than zero |
+| Flags | Polls LaunchDarkly for flag data, then pushes it to Salesforce | `FLAG_POLL_INTERVAL` | `30s` | `30s` |
+
+Both accept any [`time.ParseDuration`](https://golang.org/pkg/time/#ParseDuration) string.
+When a variable is unset, the daemon uses the historical 30-second cadence, so an
+existing deployment behaves exactly as it did before these options were added.
+
+The daemon never refuses to start over a poll interval. Instead it falls back or clamps
+and logs the interval actually in effect, so the startup log is the authoritative record
+of what the daemon is doing:
+
+| Configured value | Result |
+| --- | --- |
+| unset or empty | the `30s` default |
+| unparseable, such as `'30'` with no unit | the `30s` default |
+| below the variable's minimum | clamped up to that minimum |
+
+Because a malformed value is treated as unset rather than as an error, check the startup
+log after changing either variable. `time.ParseDuration` requires a unit, so `'30'` is
+not 30 seconds -- it does not parse, and the daemon quietly keeps the default.
+
+Note that `HTTP_TIMEOUT` does not behave this way: an unparseable `HTTP_TIMEOUT` stops
+the daemon with an error.
+
+### Choosing an event interval
+
+`FLAG_POLL_INTERVAL` is floored at 30 seconds to match the minimum polling interval
+used across LaunchDarkly's server SDKs. `EVENT_POLL_INTERVAL` has no such floor,
+because draining events more often is a reasonable tradeoff to make -- but it is a
+tradeoff worth understanding before you make it.
+
+Every drain is one inbound Salesforce REST call, and inbound calls count against your
+org's 24-hour API request allocation. (The SOQL query and DML delete the drain performs
+run inside the Apex transaction and count against per-transaction governor limits, not
+the daily API allocation.) `FLAG_POLL_INTERVAL` contributes too, since pushing flag data
+to Salesforce is also an inbound call.
+
+Salesforce allocates API requests per 24 hours by edition. For production orgs:
+
+| Edition | 24-hour allocation |
+| --- | --- |
+| Enterprise / Professional | 100,000 + 1,000 per license |
+| Unlimited / Performance | 100,000 + 5,000 per license |
+| Full Sandbox | 5,000,000 |
+
+So the smallest allocation a production org has to work with is about 100,000 calls per
+day. Against that, the drain alone costs:
+
+| `EVENT_POLL_INTERVAL` | Calls/day | Smallest production org (~100,000) | 200-license EE (~300,000) | 2,000-license EE (~2.1M) |
+| --- | --- | --- | --- | --- |
+| `30s` (default) | ~2,880 | 2.9% | 1.0% | 0.1% |
+| `10s` | ~8,640 | 8.6% | 2.9% | 0.4% |
+| `5s` | ~17,280 | 17% | 5.8% | 0.8% |
+| `1s` | ~86,400 | **86%** | 29% | 4% |
+
+Whether a short interval is affordable therefore depends on your edition and license
+count. On a large org a 1-second drain is a few percent of the allocation; on a small
+production org the same setting consumes most of the org's entire daily budget for this
+one integration, leaving little for everything else that calls the API.

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -26,13 +26,35 @@ import (
 )
 
 const (
-	LD_BASE_URI   = "https://sdk.launchdarkly.com"
-	LD_EVENTS_URI = "https://events.launchdarkly.com"
-	OAUTH_URI     = "https://login.salesforce.com/services/oauth2/token"
-	POLL_INTERVAL = 30 * time.Second
-	SDK_VERSION   = "1.5.1" // x-release-please-version
-	USER_AGENT    = "ApexServerClient/" + SDK_VERSION
-	HTTP_TIMEOUT  = 30 * time.Second
+	LD_BASE_URI           = "https://sdk.launchdarkly.com"
+	LD_EVENTS_URI         = "https://events.launchdarkly.com"
+	OAUTH_URI             = "https://login.salesforce.com/services/oauth2/token"
+	DEFAULT_POLL_INTERVAL = 30 * time.Second
+	SDK_VERSION           = "1.5.1" // x-release-please-version
+	USER_AGENT            = "ApexServerClient/" + SDK_VERSION
+	HTTP_TIMEOUT          = 30 * time.Second
+	// MIN_FLAG_POLL_INTERVAL is the shortest FLAG_POLL_INTERVAL the bridge honors,
+	// matching the minimum polling interval used across LaunchDarkly's server SDKs.
+	// A shorter configured value is clamped up to it.
+	//
+	// This must stay less than or equal to DEFAULT_POLL_INTERVAL. The fallback is
+	// range-checked along with everything else, so a minimum above the default would
+	// clamp the default itself and make it unreachable.
+	//
+	// EVENT_POLL_INTERVAL has no counterpart: draining events more often is a
+	// legitimate tradeoff against Salesforce API consumption, so its only rule is
+	// that the interval be positive.
+	MIN_FLAG_POLL_INTERVAL = 30 * time.Second
+	// EVENT_POLL_INTERVAL_WARN_THRESHOLD is the point below which a configured
+	// EVENT_POLL_INTERVAL earns a warning at startup. It is advisory only -- no floor
+	// is enforced, because whether a short interval is affordable depends on the org's
+	// edition and license count, which the bridge cannot know.
+	//
+	// 5s is where the cost stops being incidental against the smallest production
+	// allocation. Enterprise and Professional orgs start at 100,000 API calls per 24
+	// hours, and a 5s drain spends roughly 17,280 of them, about 17%. Below that the
+	// curve steepens fast: 2s is around 43% and 1s around 86% of the same allocation.
+	EVENT_POLL_INTERVAL_WARN_THRESHOLD = 5 * time.Second
 	// INSTANCE_ID_HEADER is the HTTP header used to identify this bridge instance for
 	// estimating server-connection-minutes when polling LaunchDarkly. Its value is a
 	// v4 UUID generated once per bridge process and constant for that process's lifetime.
@@ -58,9 +80,30 @@ type Bridge struct {
 	// LaunchDarkly-bound request (see INSTANCE_ID_HEADER) so the platform can estimate
 	// server-connection-minutes for polling clients.
 	instanceID string
-	lock       sync.Mutex
-	context    context.Context
-	cancel     context.CancelFunc
+	// eventPollInterval is how long eventLoop waits between drains of EventData__c,
+	// and flagPollInterval is how long featureLoop waits between flag polls. Both
+	// default to DEFAULT_POLL_INTERVAL and are configurable per loop.
+	eventPollInterval time.Duration
+	flagPollInterval  time.Duration
+	lock              sync.Mutex
+	context           context.Context
+	cancel            context.CancelFunc
+}
+
+func parseDurationFromEnv(name string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(name)
+	if raw == "" {
+		log.Printf("%s is not set, using the default of %s", name, fallback)
+		return fallback
+	}
+
+	parsed, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Printf("%s (%s) failed to parse to a duration, using %s", name, raw, fallback)
+		return fallback
+	}
+
+	return parsed
 }
 
 func newBridge() (*Bridge, error) {
@@ -147,6 +190,23 @@ func newBridge() (*Bridge, error) {
 			return nil, errors.New("HTTP_TIMEOUT must be >= 0")
 		}
 		httpTimeoutDuration = httpTimeout
+	}
+
+	bridge.eventPollInterval = parseDurationFromEnv("EVENT_POLL_INTERVAL", DEFAULT_POLL_INTERVAL)
+	if bridge.eventPollInterval <= 0 {
+		log.Printf("%s duration (%s) is non-positive, using %s", "EVENT_POLL_INTERVAL", bridge.eventPollInterval, DEFAULT_POLL_INTERVAL)
+		bridge.eventPollInterval = DEFAULT_POLL_INTERVAL
+	}
+
+	if bridge.eventPollInterval < EVENT_POLL_INTERVAL_WARN_THRESHOLD {
+		log.Printf("event flush interval is %s, polling may trigger organization wide API limits",
+			bridge.eventPollInterval)
+	}
+
+	bridge.flagPollInterval = parseDurationFromEnv("FLAG_POLL_INTERVAL", DEFAULT_POLL_INTERVAL)
+	if bridge.flagPollInterval < MIN_FLAG_POLL_INTERVAL {
+		log.Printf("%s duration (%s) is less than the minimum of %s, using %s", "FLAG_POLL_INTERVAL", bridge.flagPollInterval, MIN_FLAG_POLL_INTERVAL, MIN_FLAG_POLL_INTERVAL)
+		bridge.flagPollInterval = MIN_FLAG_POLL_INTERVAL
 	}
 
 	bridge.client = http.Client{
@@ -336,7 +396,6 @@ func (bridge *Bridge) eventLoop() error {
 			log.Print("pushing events to: " + pushURI)
 
 			pushResponse, err := bridge.client.Do(pushRequest)
-
 			if err != nil {
 				log.Print("failed pushing events to LaunchDarkly")
 				goto End
@@ -353,18 +412,18 @@ func (bridge *Bridge) eventLoop() error {
 		}
 
 	End:
-		log.Print("event polling waiting for: ", POLL_INTERVAL)
+		log.Print("event polling waiting for: ", bridge.eventPollInterval)
 
 		select {
 		case <-bridge.context.Done():
 			return nil
-		case <-time.After(POLL_INTERVAL):
+		case <-time.After(bridge.eventPollInterval):
 		}
 	}
 }
 
 func (bridge *Bridge) featureLoop() error {
-	var etag = ""
+	etag := ""
 
 	pollURI := bridge.launchDarklyBaseURI + "/sdk/latest-all"
 
@@ -441,12 +500,12 @@ func (bridge *Bridge) featureLoop() error {
 		}
 
 	End:
-		log.Print("feature polling waiting for: ", POLL_INTERVAL)
+		log.Print("feature polling waiting for: ", bridge.flagPollInterval)
 
 		select {
 		case <-bridge.context.Done():
 			return nil
-		case <-time.After(POLL_INTERVAL):
+		case <-time.After(bridge.flagPollInterval):
 		}
 	}
 }

--- a/bridge/main_test.go
+++ b/bridge/main_test.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -25,8 +30,14 @@ func newTestBridge(t *testing.T, baseURI, eventsURI string) *Bridge {
 		launchDarklyBaseURI:   baseURI,
 		launchDarklyEventsURI: eventsURI,
 		instanceID:            uuid.New().String(),
-		context:               ctx,
-		cancel:                cancel,
+		// The poll intervals must be positive here. These tests cancel the context
+		// from inside the request handler and rely on the loop's select landing on
+		// ctx.Done(); a zero interval would make time.After ready at the same moment
+		// and let select pick the timer branch instead, causing extra polls.
+		eventPollInterval: DEFAULT_POLL_INTERVAL,
+		flagPollInterval:  DEFAULT_POLL_INTERVAL,
+		context:           ctx,
+		cancel:            cancel,
 	}
 }
 
@@ -136,5 +147,363 @@ func TestInstanceIDsAreUniquePerInstance(t *testing.T) {
 	}
 	if a.instanceID == b.instanceID {
 		t.Errorf("expected distinct instance ids across bridges, both were %q", a.instanceID)
+	}
+}
+
+// restoreEnv arranges for name to be returned to its current value once the test
+// finishes. t.Setenv would handle this but requires Go 1.17, and CI builds the
+// bridge with Go 1.15.
+func restoreEnv(t *testing.T, name string) {
+	t.Helper()
+	previous, had := os.LookupEnv(name)
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(name, previous)
+		} else {
+			_ = os.Unsetenv(name)
+		}
+	})
+}
+
+// setEnv sets an environment variable for the duration of a test.
+func setEnv(t *testing.T, name, value string) {
+	t.Helper()
+	restoreEnv(t, name)
+	if err := os.Setenv(name, value); err != nil {
+		t.Fatalf("failed setting %s: %v", name, err)
+	}
+}
+
+// unsetEnv removes an environment variable for the duration of a test. This is
+// distinct from setting it to the empty string: both resolve to the fallback, but
+// only the unset case reflects a bridge that was never configured at all.
+func unsetEnv(t *testing.T, name string) {
+	t.Helper()
+	restoreEnv(t, name)
+	if err := os.Unsetenv(name); err != nil {
+		t.Fatalf("failed unsetting %s: %v", name, err)
+	}
+}
+
+// setMinimalBridgeEnv populates just enough environment for newBridge to succeed,
+// using the password auth branch so no RSA key is needed. newBridge performs no
+// network I/O -- Salesforce authorization happens later, from run() -- so calling it
+// directly in a test is safe. Optional variables are cleared so a value left in the
+// developer's shell cannot influence the result.
+func setMinimalBridgeEnv(t *testing.T) {
+	t.Helper()
+	setEnv(t, "LD_SDK_KEY", "sdk-test-key")
+	setEnv(t, "SALESFORCE_URL", "https://example.invalid/services/apexrest/")
+	setEnv(t, "OAUTH_ID", "test-oauth-id")
+	setEnv(t, "OAUTH_USERNAME", "test@example.invalid")
+	setEnv(t, "OAUTH_PASSWORD", "test-password")
+	setEnv(t, "OAUTH_SECRET", "test-secret")
+	for _, name := range []string{"OAUTH_JWT_KEY", "OAUTH_URI", "HTTP_TIMEOUT", "LD_BASE_URI", "LD_EVENTS_URI"} {
+		unsetEnv(t, name)
+	}
+}
+
+// TestParseDurationFromEnv covers the parsing layer on its own. An unset, empty, or
+// unparseable value yields the fallback; anything time.ParseDuration accepts comes
+// back as-is. Range enforcement is a separate concern applied by newBridge, so a
+// negative duration passes through this function unchanged.
+func TestParseDurationFromEnv(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  time.Duration
+	}{
+		{name: "unset yields the fallback", set: false, want: DEFAULT_POLL_INTERVAL},
+		{name: "empty yields the fallback", value: "", set: true, want: DEFAULT_POLL_INTERVAL},
+		{name: "seconds", value: "45s", set: true, want: 45 * time.Second},
+		{name: "minutes", value: "5m", set: true, want: 5 * time.Minute},
+		{name: "milliseconds", value: "100ms", set: true, want: 100 * time.Millisecond},
+		{name: "compound", value: "1m30s", set: true, want: 90 * time.Second},
+		{name: "zero passes through", value: "0s", set: true, want: 0},
+		{name: "negative passes through", value: "-5s", set: true, want: -5 * time.Second},
+		// time.ParseDuration requires a unit, so a bare number is the likeliest
+		// operator mistake. These fall back rather than failing startup.
+		{name: "bare number yields the fallback", value: "30", set: true, want: DEFAULT_POLL_INTERVAL},
+		{name: "garbage yields the fallback", value: "abc", set: true, want: DEFAULT_POLL_INTERVAL},
+		{name: "embedded space yields the fallback", value: "30 s", set: true, want: DEFAULT_POLL_INTERVAL},
+		{name: "spelled-out unit yields the fallback", value: "1minute", set: true, want: DEFAULT_POLL_INTERVAL},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			if test.set {
+				setEnv(t, "EVENT_POLL_INTERVAL", test.value)
+			} else {
+				unsetEnv(t, "EVENT_POLL_INTERVAL")
+			}
+
+			got := parseDurationFromEnv("EVENT_POLL_INTERVAL", DEFAULT_POLL_INTERVAL)
+			if got != test.want {
+				t.Errorf("parseDurationFromEnv = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+// TestNewBridgeResolvesEventPollInterval exercises the path the daemon actually
+// takes, parsing and range-checking together. The only rule for EVENT_POLL_INTERVAL
+// is that it end up positive: time.After fires immediately on a non-positive
+// duration, which would turn the poll loop into a hot spin against Salesforce.
+func TestNewBridgeResolvesEventPollInterval(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  time.Duration
+	}{
+		{name: "unset falls back to the default", set: false, want: DEFAULT_POLL_INTERVAL},
+		{name: "empty falls back to the default", value: "", set: true, want: DEFAULT_POLL_INTERVAL},
+		{name: "longer than the default is honored", value: "5m", set: true, want: 5 * time.Minute},
+		{name: "shorter than the default is honored", value: "1s", set: true, want: time.Second},
+		{name: "sub-second is honored", value: "100ms", set: true, want: 100 * time.Millisecond},
+		{name: "zero is clamped to the default", value: "0s", set: true, want: DEFAULT_POLL_INTERVAL},
+		{name: "negative is clamped to the default", value: "-5s", set: true, want: DEFAULT_POLL_INTERVAL},
+		{name: "unparseable falls back to the default", value: "30", set: true, want: DEFAULT_POLL_INTERVAL},
+	}
+
+	// The API-consumption warning below EVENT_POLL_INTERVAL_WARN_THRESHOLD is advisory,
+	// so aggressive values must still be honored exactly as configured. The table above
+	// covers that: "1s" and "100ms" are both under the threshold and both pass through.
+	// TestEventPollIntervalAPIWarning covers the warning itself.
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			setMinimalBridgeEnv(t)
+			if test.set {
+				setEnv(t, "EVENT_POLL_INTERVAL", test.value)
+			} else {
+				unsetEnv(t, "EVENT_POLL_INTERVAL")
+			}
+
+			bridge, err := newBridge()
+			if err != nil {
+				t.Fatalf("newBridge returned unexpected error: %v", err)
+			}
+			if bridge.eventPollInterval != test.want {
+				t.Errorf("eventPollInterval = %s, want %s", bridge.eventPollInterval, test.want)
+			}
+			if bridge.eventPollInterval <= 0 {
+				t.Errorf("eventPollInterval %s is not positive; time.After would hot-spin the loop",
+					bridge.eventPollInterval)
+			}
+		})
+	}
+}
+
+// TestNewBridgeResolvesFlagPollInterval is the FLAG_POLL_INTERVAL counterpart. This
+// one enforces a 30s floor, matching the minimum polling interval used across
+// LaunchDarkly's server SDKs, so a value below it is clamped up rather than honored.
+func TestNewBridgeResolvesFlagPollInterval(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  time.Duration
+	}{
+		{name: "unset falls back to the default", set: false, want: DEFAULT_POLL_INTERVAL},
+		{name: "empty falls back to the default", value: "", set: true, want: DEFAULT_POLL_INTERVAL},
+		{name: "exactly the minimum is honored", value: "30s", set: true, want: MIN_FLAG_POLL_INTERVAL},
+		{name: "longer than the minimum is honored", value: "5m", set: true, want: 5 * time.Minute},
+		{name: "below the minimum is clamped up", value: "10s", set: true, want: MIN_FLAG_POLL_INTERVAL},
+		{name: "just below the minimum is clamped up", value: "29999ms", set: true, want: MIN_FLAG_POLL_INTERVAL},
+		{name: "zero is clamped up", value: "0s", set: true, want: MIN_FLAG_POLL_INTERVAL},
+		{name: "negative is clamped up", value: "-5s", set: true, want: MIN_FLAG_POLL_INTERVAL},
+		{name: "unparseable falls back to the default", value: "30", set: true, want: DEFAULT_POLL_INTERVAL},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			setMinimalBridgeEnv(t)
+			if test.set {
+				setEnv(t, "FLAG_POLL_INTERVAL", test.value)
+			} else {
+				unsetEnv(t, "FLAG_POLL_INTERVAL")
+			}
+
+			bridge, err := newBridge()
+			if err != nil {
+				t.Fatalf("newBridge returned unexpected error: %v", err)
+			}
+			if bridge.flagPollInterval != test.want {
+				t.Errorf("flagPollInterval = %s, want %s", bridge.flagPollInterval, test.want)
+			}
+			if bridge.flagPollInterval < MIN_FLAG_POLL_INTERVAL {
+				t.Errorf("flagPollInterval %s is below the %s minimum",
+					bridge.flagPollInterval, MIN_FLAG_POLL_INTERVAL)
+			}
+		})
+	}
+}
+
+// TestEventLoopUsesConfiguredInterval verifies the resolved interval is actually
+// wired into eventLoop's wait rather than the POLL_INTERVAL constant. A short
+// interval must produce several polls promptly; if the constant were still in use
+// the second poll would be 30s away and this test would time out.
+func TestEventLoopUsesConfiguredInterval(t *testing.T) {
+	const wantPolls = 3
+
+	var mu sync.Mutex
+	polls := 0
+	var cancel context.CancelFunc
+
+	sfServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		polls++
+		reached := polls >= wantPolls
+		mu.Unlock()
+
+		if reached {
+			cancel()
+		}
+		// An empty array short-circuits the push to LaunchDarkly, keeping this test
+		// focused on the loop's cadence.
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer sfServer.Close()
+
+	bridge := newTestBridge(t, "http://unused.invalid", "http://unused.invalid")
+	bridge.salesforceURL = sfServer.URL + "/"
+	bridge.oauthCurrentToken = "test-token"
+	bridge.eventPollInterval = time.Millisecond
+	cancel = bridge.cancel
+
+	done := make(chan error, 1)
+	go func() { done <- bridge.eventLoop() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("eventLoop returned unexpected error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("eventLoop did not honor the configured interval (still waiting on POLL_INTERVAL?)")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Cancelling races the timer branch of the loop's select, so a few extra polls
+	// past the threshold are expected and fine.
+	if polls < wantPolls {
+		t.Errorf("eventLoop polled %d times, want at least %d", polls, wantPolls)
+	}
+}
+
+// TestFeatureLoopUsesConfiguredInterval is the featureLoop counterpart to
+// TestEventLoopUsesConfiguredInterval. The 30s floor applies to what an operator
+// may configure, not to what the loop is capable of, so the field is set directly.
+func TestFeatureLoopUsesConfiguredInterval(t *testing.T) {
+	const wantPolls = 3
+
+	var mu sync.Mutex
+	polls := 0
+	var cancel context.CancelFunc
+
+	ldServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		polls++
+		reached := polls >= wantPolls
+		mu.Unlock()
+
+		if reached {
+			cancel()
+		}
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer ldServer.Close()
+
+	bridge := newTestBridge(t, ldServer.URL, ldServer.URL)
+	bridge.flagPollInterval = time.Millisecond
+	cancel = bridge.cancel
+
+	done := make(chan error, 1)
+	go func() { done <- bridge.featureLoop() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("featureLoop returned unexpected error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("featureLoop did not honor the configured interval (still waiting on POLL_INTERVAL?)")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if polls < wantPolls {
+		t.Errorf("featureLoop polled %d times, want at least %d", polls, wantPolls)
+	}
+}
+
+// captureLog redirects the standard logger for the duration of a test and returns a
+// buffer holding whatever was written to it.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	previousFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(previousFlags)
+	})
+	return &buf
+}
+
+// TestEventPollIntervalAPIWarning covers the advisory warning for an aggressive event
+// interval. Every drain is an inbound Salesforce API call counted against the org's
+// 24-hour allocation, and exhausting that allocation returns REQUEST_LIMIT_EXCEEDED to
+// every API client in the org rather than just this bridge -- so a short interval is
+// worth flagging even though it stays honored.
+func TestEventPollIntervalAPIWarning(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		wantWarning bool
+	}{
+		{name: "one second warns", value: "1s", wantWarning: true},
+		{name: "sub-second warns", value: "100ms", wantWarning: true},
+		{name: "just below the threshold warns", value: "4999ms", wantWarning: true},
+		{name: "exactly the threshold is quiet", value: "5s", wantWarning: false},
+		{name: "the default is quiet", value: "30s", wantWarning: false},
+		// A negative value is clamped to the default before the threshold is examined,
+		// so it must not also trip the warning.
+		{name: "negative is clamped and stays quiet", value: "-5s", wantWarning: false},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			setMinimalBridgeEnv(t)
+			setEnv(t, "EVENT_POLL_INTERVAL", test.value)
+			logged := captureLog(t)
+
+			bridge, err := newBridge()
+			if err != nil {
+				t.Fatalf("newBridge returned unexpected error: %v", err)
+			}
+
+			// This phrase appears only in the API-consumption warning, so it is a
+			// reliable marker for that specific message.
+			warned := strings.Contains(logged.String(), "organization wide API limits")
+			if warned != test.wantWarning {
+				t.Errorf("interval %s resolved to %s: warned = %v, want %v\nlog:\n%s",
+					test.value, bridge.eventPollInterval, warned, test.wantWarning, logged.String())
+			}
+			// The warning must name the interval in effect, since that is the only
+			// actionable detail it carries.
+			if test.wantWarning && !strings.Contains(logged.String(), bridge.eventPollInterval.String()) {
+				t.Errorf("warning does not name the effective interval %s\nlog:\n%s",
+					bridge.eventPollInterval, logged.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
The bridge polled on a hardcoded 30-second cadence shared by both loops, so
retuning it required a code change and a redeploy. Each loop is now
independently configurable:

  EVENT_POLL_INTERVAL - how often EventData__c is drained from Salesforce
  FLAG_POLL_INTERVAL  - how often LaunchDarkly is polled for flag data

Both accept a time.ParseDuration string. Environment variables were chosen over
command-line flags because every existing option is already an env var, several
of them are secrets that must not appear in argv, and env vars work uniformly
under systemd Environment=, docker -e, and a shell export. Introducing flags
for only these two options would leave the configuration surface split.

When a variable is unset both loops fall back to DEFAULT_POLL_INTERVAL, renamed
from POLL_INTERVAL now that it is a default rather than the only value, so an
existing deployment is unaffected.

Resolution is deliberately forgiving: a poll interval never stops startup.
parseDurationFromEnv falls back to the default when a variable is unset or
cannot be parsed, and newBridge then range-checks the result. Because a
malformed value is treated as unset, the effective interval is logged in every
case so the startup log is the authoritative record of what the daemon is
doing. Note this differs from HTTP_TIMEOUT, which still fails startup on an
unparseable value; the README calls the inconsistency out.

FLAG_POLL_INTERVAL is clamped up to MIN_FLAG_POLL_INTERVAL, matching the
minimum polling interval used across LaunchDarkly's server SDKs. That constant
must stay at or below DEFAULT_POLL_INTERVAL: the fallback is range-checked like
any other value, so a higher minimum would clamp the default itself and make it
unreachable. EVENT_POLL_INTERVAL has no minimum beyond being positive, since
draining more often is a legitimate tradeoff against Salesforce API
consumption. The check is against zero rather than a nominal floor because
time.ParseDuration accepts negative durations, and a non-positive duration makes
time.After fire immediately and turns the poll loop into a hot spin.

Because every drain is one inbound Salesforce REST call charged against the
org's 24-hour API request allocation, the daemon warns at startup when
EVENT_POLL_INTERVAL is below 5 seconds, naming the interval in effect.
Enterprise and Professional orgs start at 100,000 calls per 24 hours, so the
smallest allocation a production org has to work with is around 100,000. A 5s
drain spends roughly 17,280 of those, about 17%, and below that the curve
steepens quickly: around 43% at 2s and 86% at 1s. That is where the threshold
comes from.

No floor is enforced. Whether a short interval is affordable depends on the
org's edition, license count, and whatever else in the org draws on the same
allocation, none of which the bridge can know. The reason to warn rather than
stay silent is blast radius: exhausting the allocation returns
REQUEST_LIMIT_EXCEEDED to every API client in the org, not just this bridge.

Tests drive newBridge itself rather than a resolver in isolation, so parsing and
range enforcement are covered on the path the daemon actually takes. The clamps
and the warning were each verified by mutation: removing an assignment, dropping
the warning, or inverting its comparison all fail the suite.

newTestBridge now sets both intervals explicitly. The existing tests cancel the
context from inside the request handler and rely on the loop's select landing on
ctx.Done(); a zero-valued interval would make time.After ready at the same
moment and let select take the timer branch instead.

The README documents both variables, the resolution table, and the per-edition
API allocations for production orgs with the share each interval consumes. It
also corrects an accounting error: the SOQL query and DML
delete a drain performs do not consume the daily API allocation. Those run
inside the Apex transaction and count against per-transaction governor limits;
only the inbound REST call is charged. FLAG_POLL_INTERVAL's push to Salesforce
is an inbound call as well, so at the default cadence the bridge costs up to
~5,760 calls per day.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misconfigured short event intervals can consume a large share of an org's daily Salesforce API quota and affect other integrations, though defaults preserve prior 30s behavior.
> 
> **Overview**
> Replaces the shared **30s** hardcoded poll cadence with **independent** env-driven intervals for the Salesforce event drain and LaunchDarkly flag sync loops, so operators can tune behavior without redeploying code.
> 
> **`EVENT_POLL_INTERVAL`** and **`FLAG_POLL_INTERVAL`** use `time.ParseDuration` strings; unset or bad values **fall back to 30s** and log the effective interval (unlike **`HTTP_TIMEOUT`**, which still fails startup on parse errors). Event intervals must be **positive** (non-positive values reset to default to avoid a hot spin); flag intervals are **clamped to a 30s minimum** (LaunchDarkly server SDK alignment). **`EVENT_POLL_INTERVAL` below 5s** still runs but logs an **org-wide Salesforce API limit** warning.
> 
> The README adds configuration docs, resolution rules, and guidance on API call cost per interval. Tests cover env parsing, `newBridge` resolution, loop wiring, and the advisory warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3da769f00359c070359ba3b8d67cdb0ad95ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->