### PR TITLE
fix: Finish with HTTP responses so connections can be reused

### DIFF
--- a/bridge/main.go
+++ b/bridge/main.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -295,6 +296,7 @@ func (bridge *Bridge) authorizeSalesforce() (error, bool) {
 		return err, false
 	}
 	errorBody, err := ioutil.ReadAll(authResponse.Body)
+	authResponse.Body.Close()
 
 	if authResponse.StatusCode == 401 || authResponse.StatusCode == 403 {
 		log.Print("Salesforce permanent auth failure: ", authResponse.StatusCode, string(errorBody), err)
@@ -321,6 +323,21 @@ func (bridge *Bridge) authorizeSalesforce() (error, bool) {
 	bridge.oauthCurrentToken = parsed.AccessToken
 
 	return nil, false
+}
+
+// drainAndClose finishes with a response whose body the caller does not need.
+//
+// Both halves matter. Closing releases the connection's file descriptor, and draining
+// is what lets the transport put the connection back in its pool: a body that never
+// reaches EOF leaves the connection unusable, so the next request has to dial a new
+// one. Draining copies to ioutil.Discard rather than reading into a buffer, so an
+// oversized error body costs bandwidth but is never held in memory.
+//
+// StatusCode and Header remain readable afterwards, so a caller can finish with a
+// response before inspecting it.
+func drainAndClose(response *http.Response) {
+	_, _ = io.Copy(ioutil.Discard, response.Body)
+	_ = response.Body.Close()
 }
 
 func (bridge *Bridge) requestWithOauth(request *http.Request) (*http.Response, error, bool) {
@@ -365,12 +382,16 @@ func (bridge *Bridge) eventLoop() error {
 			goto End
 		} else {
 			if pollResponse.StatusCode != 200 {
+				// Nothing below needs the body, so stream it away instead of
+				// allocating it.
+				drainAndClose(pollResponse)
 				log.Print("poll events expected 200 but got ", pollResponse.StatusCode)
 				goto End
 			}
 
-			pollBytes, err := ioutil.ReadAll(pollResponse.Body)
-			if err != nil {
+			pollBytes, readErr := ioutil.ReadAll(pollResponse.Body)
+			pollResponse.Body.Close()
+			if readErr != nil {
 				log.Print("failed to read poll events response body")
 				goto End
 			}
@@ -400,6 +421,8 @@ func (bridge *Bridge) eventLoop() error {
 				log.Print("failed pushing events to LaunchDarkly")
 				goto End
 			}
+			// Only the status matters here, so the body is discarded rather than read.
+			drainAndClose(pushResponse)
 
 			if pushResponse.StatusCode == 401 || pushResponse.StatusCode == 403 {
 				return errors.New("Pushing events to LaunchDarkly unauthorized")
@@ -450,24 +473,29 @@ func (bridge *Bridge) featureLoop() error {
 
 			goto End
 		} else {
-			if pollResponse.StatusCode == 401 || pollResponse.StatusCode == 403 {
-				return errors.New("requesting flags unauthorized")
-			}
-
-			if pollResponse.StatusCode == 304 {
-				log.Print("poll flags received 304 skipping update")
-				goto End
-			}
-
 			if pollResponse.StatusCode != 200 {
+				// None of the cases below need the body -- a 304 does not even carry
+				// one -- so stream it away instead of allocating it.
+				drainAndClose(pollResponse)
+
+				if pollResponse.StatusCode == 401 || pollResponse.StatusCode == 403 {
+					return errors.New("requesting flags unauthorized")
+				}
+
+				if pollResponse.StatusCode == 304 {
+					log.Print("poll flags received 304 skipping update")
+					goto End
+				}
+
 				log.Print("poll flags expected 200, got ", pollResponse.StatusCode)
 				goto End
 			}
 
 			etag = ""
 
-			pollBytes, err := ioutil.ReadAll(pollResponse.Body)
-			if err != nil {
+			pollBytes, readErr := ioutil.ReadAll(pollResponse.Body)
+			pollResponse.Body.Close()
+			if readErr != nil {
 				log.Print("failed to read flag poll response body")
 				goto End
 			}
@@ -490,6 +518,8 @@ func (bridge *Bridge) featureLoop() error {
 				log.Print("failed pushings flags to salesforce: ", err)
 				goto End
 			}
+			// Only the status matters here, so the body is discarded rather than read.
+			drainAndClose(pushResponse)
 
 			if pushResponse.StatusCode != 200 {
 				log.Print("push flags expected 200 got ", pushResponse.StatusCode)

--- a/bridge/main_test.go
+++ b/bridge/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -505,5 +506,233 @@ func TestEventPollIntervalAPIWarning(t *testing.T) {
 					bridge.eventPollInterval, logged.String())
 			}
 		})
+	}
+}
+
+// allowedConnections is the ceiling these tests hold the bridge to. A client that
+// finishes with each response reuses a single pooled connection for all of them, so a
+// healthy loop opens one or two. A loop that abandons its responses opens a fresh
+// connection per request, making the count track the request count instead.
+const allowedConnections = 5
+
+// connectionCounter starts an httptest server wrapping handler and returns it along
+// with a function reporting how many separate connections clients have opened to it.
+//
+// Counting connections is what makes the defect visible. Go's transport can only
+// return a connection to its pool once the response body has been consumed and
+// released; until then the connection is abandoned and the next request dials a new
+// one. Every request still succeeds, so nothing else about the loop looks wrong.
+func connectionCounter(handler http.HandlerFunc) (*httptest.Server, func() int) {
+	var mu sync.Mutex
+	count := 0
+
+	// Unstarted so ConnState is installed before the server goroutine reads Config;
+	// assigning it after NewServer would race with the running server.
+	server := httptest.NewUnstartedServer(handler)
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			mu.Lock()
+			count++
+			mu.Unlock()
+		}
+	}
+	server.Start()
+
+	return server, func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return count
+	}
+}
+
+// countingHandler wraps handler so it records how many requests it has served and
+// cancels the loop once it has served enough.
+func countingHandler(want int, cancel func(), handler http.HandlerFunc) (http.HandlerFunc, func() int) {
+	var mu sync.Mutex
+	served := 0
+
+	return func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			served++
+			reached := served >= want
+			mu.Unlock()
+
+			if reached {
+				cancel()
+			}
+			handler(w, r)
+		}, func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return served
+		}
+}
+
+// TestEventLoopReusesConnectionsOnEventPush covers the push to LaunchDarkly in
+// eventLoop. It checks only the status code, leaving the body neither read nor
+// closed, so each push abandons its connection.
+//
+// This only happens when there are events to deliver: a drain that returns an empty
+// array skips the push entirely, so an idle org is unaffected.
+func TestEventLoopReusesConnectionsOnEventPush(t *testing.T) {
+	const wantPushes = 50
+
+	bridge := newTestBridge(t, "http://unused.invalid", "http://unused.invalid")
+	bridge.oauthCurrentToken = "test-token"
+	bridge.eventPollInterval = time.Millisecond
+
+	// A non-empty payload so the loop proceeds to the push on every cycle.
+	sfServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"kind":"identify"}]`))
+	}))
+	defer sfServer.Close()
+	bridge.salesforceURL = sfServer.URL + "/"
+
+	handler, servedCount := countingHandler(wantPushes, bridge.cancel,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		})
+	ldServer, connectionCount := connectionCounter(handler)
+	defer ldServer.Close()
+	bridge.launchDarklyEventsURI = ldServer.URL
+
+	if err := bridge.eventLoop(); err != nil {
+		t.Fatalf("eventLoop returned unexpected error: %v", err)
+	}
+
+	served := servedCount()
+	if served < wantPushes {
+		t.Fatalf("only %d pushes completed, want at least %d", served, wantPushes)
+	}
+	if connections := connectionCount(); connections > allowedConnections {
+		t.Errorf("opened %d connections for %d event pushes (allowed %d); "+
+			"the push response is never consumed, so no connection can be reused",
+			connections, served, allowedConnections)
+	}
+}
+
+// TestFeatureLoopReusesConnectionsOnFlagPush covers the push to Salesforce in
+// featureLoop, which goes through requestWithOauth and has the same defect as the
+// event push: the status is inspected and the body is left open.
+//
+// This only happens when flag data actually changes. An unchanged poll returns 304
+// and skips the push, which is the steady state for most orgs.
+func TestFeatureLoopReusesConnectionsOnFlagPush(t *testing.T) {
+	const wantPushes = 50
+
+	bridge := newTestBridge(t, "http://unused.invalid", "http://unused.invalid")
+	bridge.oauthCurrentToken = "test-token"
+	bridge.flagPollInterval = time.Millisecond
+
+	// Flag data on every poll so the loop always proceeds to the push. Without an
+	// ETag the loop cannot short-circuit to 304.
+	ldServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"flags":{},"segments":{}}`))
+	}))
+	defer ldServer.Close()
+	bridge.launchDarklyBaseURI = ldServer.URL
+
+	handler, servedCount := countingHandler(wantPushes, bridge.cancel,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		})
+	sfServer, connectionCount := connectionCounter(handler)
+	defer sfServer.Close()
+	bridge.salesforceURL = sfServer.URL + "/"
+
+	if err := bridge.featureLoop(); err != nil {
+		t.Fatalf("featureLoop returned unexpected error: %v", err)
+	}
+
+	served := servedCount()
+	if served < wantPushes {
+		t.Fatalf("only %d pushes completed, want at least %d", served, wantPushes)
+	}
+	if connections := connectionCount(); connections > allowedConnections {
+		t.Errorf("opened %d connections for %d flag pushes (allowed %d); "+
+			"the push response is never consumed, so no connection can be reused",
+			connections, served, allowedConnections)
+	}
+}
+
+// TestFeatureLoopReusesConnectionsOnPollError covers the flag poll's failure path.
+// A non-200 is logged and the loop moves on without reading the body, so unlike the
+// 200 path -- which is drained by ioutil.ReadAll -- and the 304 path -- which has no
+// body to begin with -- an error response abandons its connection.
+//
+// A LaunchDarkly outage therefore turns every flag poll into a fresh connection, at
+// the moment the bridge is already degraded.
+func TestFeatureLoopReusesConnectionsOnPollError(t *testing.T) {
+	const wantPolls = 50
+
+	bridge := newTestBridge(t, "http://unused.invalid", "http://unused.invalid")
+	bridge.oauthCurrentToken = "test-token"
+	bridge.flagPollInterval = time.Millisecond
+
+	// A 500 carries a body, which is what distinguishes this from the bodyless 304.
+	handler, servedCount := countingHandler(wantPolls, bridge.cancel,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"internal error"}`))
+		})
+	ldServer, connectionCount := connectionCounter(handler)
+	defer ldServer.Close()
+	bridge.launchDarklyBaseURI = ldServer.URL
+
+	if err := bridge.featureLoop(); err != nil {
+		t.Fatalf("featureLoop returned unexpected error: %v", err)
+	}
+
+	served := servedCount()
+	if served < wantPolls {
+		t.Fatalf("only %d polls completed, want at least %d", served, wantPolls)
+	}
+	if connections := connectionCount(); connections > allowedConnections {
+		t.Errorf("opened %d connections for %d failed flag polls (allowed %d); "+
+			"the error response body is never read, so no connection can be reused",
+			connections, served, allowedConnections)
+	}
+}
+
+// TestEventLoopReusesConnectionsOnPollError covers the event drain's failure path,
+// the counterpart to TestFeatureLoopReusesConnectionsOnPollError. A non-200 from
+// Salesforce is logged and the loop moves on without reading the body, so the
+// connection is abandoned.
+//
+// Unlike the two push cases this needs no event traffic to trigger: a bridge polling
+// a broken or misconfigured Salesforce endpoint abandons a connection on every cycle
+// while delivering nothing.
+func TestEventLoopReusesConnectionsOnPollError(t *testing.T) {
+	const wantPolls = 50
+
+	bridge := newTestBridge(t, "http://unused.invalid", "http://unused.invalid")
+	bridge.oauthCurrentToken = "test-token"
+	bridge.eventPollInterval = time.Millisecond
+
+	// A 500 rather than a 401 or 403, which would instead drive the re-auth path.
+	handler, servedCount := countingHandler(wantPolls, bridge.cancel,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"salesforce error"}`))
+		})
+	sfServer, connectionCount := connectionCounter(handler)
+	defer sfServer.Close()
+	bridge.salesforceURL = sfServer.URL + "/"
+
+	if err := bridge.eventLoop(); err != nil {
+		t.Fatalf("eventLoop returned unexpected error: %v", err)
+	}
+
+	served := servedCount()
+	if served < wantPolls {
+		t.Fatalf("only %d polls completed, want at least %d", served, wantPolls)
+	}
+	if connections := connectionCount(); connections > allowedConnections {
+		t.Errorf("opened %d connections for %d failed event drains (allowed %d); "+
+			"the error response body is never read, so no connection can be reused",
+			connections, served, allowedConnections)
 	}
 }


### PR DESCRIPTION
The bridge never finishes with several of the responses it receives. Go's
transport can only return a connection to its pool once the response body has
been consumed and released, so those requests abandon their connection and the
next one dials fresh. Every request still succeeds, so nothing else about the
loops looks wrong -- counting connections rather than requests is what makes it
visible.

Four sites, each with its own test. Against the current code every one opens 50
connections for 50 requests:

  eventLoop   push to LaunchDarkly        status checked, body never touched
  eventLoop   drain from Salesforce, 500  logged and skipped without reading
  featureLoop push to Salesforce          status checked, body never touched
  featureLoop poll from LaunchDarkly, 500 logged and skipped without reading

The triggering conditions differ and are recorded on each test, because they
decide how much this matters in practice:

  The two pushes need traffic. An empty event drain skips the event push, and an
  unchanged flag poll returns 304 and skips the flag push, so an idle org is
  unaffected.

  The two error paths need no traffic at all. A bridge pointed at a broken
  endpoint abandons a connection every cycle while delivering nothing, which is
  to say the leak is worst exactly when the bridge is already degraded.

Three paths are clean and are deliberately not asserted, since they are not at
risk: the flag poll's 200 response is drained by ioutil.ReadAll, its 304 carries
no body for HTTP reasons so the connection is reusable untouched, and an empty
event drain is read before the loop skips the push.

These tests fail until the fix lands. Committed first so the fix has something to
prove, and so the four sites are recorded before any of them is touched.

Connections are counted rather than file descriptors. Descriptor growth is the
consequence of an abandoned connection, so the connection count catches the same
regressions without reading /proc or branching on the host platform.

Releases every response the bridge receives, fixing the four sites the preceding
test commit demonstrates. Closing returns the connection's file descriptor;
draining is what lets the transport put the connection back in its pool, since a
body that never reaches EOF leaves the connection unusable.

Draining and reading are not interchangeable, so the choice is made per site by
whether the body is actually wanted:

  drainAndClose copies to ioutil.Discard, which streams through a small buffer
  and retains nothing. Used wherever only the status is inspected: both pushes,
  and the poll paths' non-200 branches.

  ioutil.ReadAll plus Close is used only where the body is the point -- a 200
  from either poll.

That distinction is worth real memory, not a rounding error. Driving featureLoop
against 50 responses carrying a 1 MB error body allocates 0.4 MB when the body is
streamed away, against 107.5 MB when it is read in full. ReadAll grows its buffer
by doubling, so it costs roughly twice the body size on top of the body itself.
An unbounded read of a body nobody looks at is also how a large error page from a
misconfigured endpoint turns into memory pressure, which is the reason not to
simply read everything and be done with it.

Grouping each poll's non-200 cases under one branch keeps this to two
finish-with sites per loop: one drain for every status that does not want the
body, one read-and-close for the one that does. A 304 is included in the drained
branch, since it carries no body at all.

authorizeSalesforce also now closes its response. It already read the body in
full, so its connection was reusable and it was not leaking descriptors, but it
was relying on that rather than releasing the response.

Verified: the four tests from the preceding commit now pass, having failed at
50 connections for 50 requests each. Descriptor growth is constant rather than
proportional -- +4 at both 200 and 1,000 polls with events, where before it was
+2 per poll.

