### PR TITLE
feat: Support multiple LaunchDarkly projects in a single Salesforce org

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -31,6 +31,11 @@ export OAUTH_PASSWORD='Your Salesforce password + security token'
 # such as: 'mypasswordmysalesforcesecuritytoken'
 
 # optional configuration options
+export LD_PROJECT_KEY='Your LaunchDarkly project key'
+# such as: 'gps'
+# scopes this bridge to one LaunchDarkly project within the Salesforce org
+# if not set, the bridge owns records that carry no project
+# refer to "Multiple projects" below -- the Apex client must use the same value
 export OAUTH_URI='YOUR OAUTH URI'
 # if not set, defaults to: 'https://login.salesforce.com/services/oauth2/token'
 # if authenticating against sandbox, use: 'https://test.salesforce.com/services/oauth2/token'
@@ -46,6 +51,66 @@ export FLAG_POLL_INTERVAL='How often to poll LaunchDarkly for flag data'
 # if not set or unparseable, defaults to: '30s'
 # minimum is '30s'; anything shorter is clamped up to '30s'
 ```
+
+## Multiple projects
+
+A single Salesforce org can hold flag data for more than one LaunchDarkly project. Run one
+bridge per project, and give the bridge and the Apex client the *same* project key:
+
+```bash
+export LD_PROJECT_KEY='gps'
+```
+
+```apex
+LDConfig config = new LDConfig.Builder()
+    .setProjectKey('gps')
+    .build();
+LDClient client = new LDClient(config);
+```
+
+The bridge sends its key to Salesforce as an `LD-Project-Key` header, and the Apex side scopes
+every read, write and delete to it. Leaving both unset is the default and scopes everything to
+records carrying no project, which is how the SDK behaved before this option existed.
+
+**The two values must agree.** A mismatch produces no error. Evaluation simply finds no flag
+data for the configured project and every variation call returns its fallback, so check the
+bridge's startup log, which reports the key in effect.
+
+Source the project key from one place in your Apex -- a custom setting or a single constant --
+rather than at each call site. A partial rollout where some entry points name the project and
+others do not is the one state the migration below does not account for.
+
+### Migrating an existing deployment
+
+Nothing needs backfilling: the bridge replaces all of a project's flag data on every push, and
+queued events are drained continuously, so records are replaced rather than migrated.
+
+1. Deploy the new Apex with no project key configured. This changes nothing -- reads still
+   match the records your current bridge writes.
+2. Leave the existing bridge running, and start a second one with `LD_PROJECT_KEY` set. The two
+   coexist safely: each owns its own records and neither deletes the other's.
+3. Set the same key on the Apex client. Its data is already populated by step 2, so there is no
+   window where evaluation falls back.
+4. Keep both bridges running until the events that carry no project have drained. No new ones
+   are created once step 3 lands.
+5. Stop the original bridge.
+6. Delete the leftover flag data that carries no project:
+
+   ```apex
+   delete [SELECT Id FROM VersionedData__c WHERE Project__c = null LIMIT 10000];
+   ```
+
+Two details in that order are load-bearing:
+
+- **Step 5 must come before step 6.** Delete those records while the original bridge is still
+  running and its next push recreates them.
+- **Do not stop the original bridge before step 4 finishes.** Nothing else drains events that
+  carry no project, and undrained events count against that scope's `maxEventsInQueue` forever.
+
+Step 6 is a manual step by design. Each bridge only ever deletes its own project's records, so
+records left behind by a decommissioned bridge are not cleaned up for you. The `LIMIT` is there
+because a single DML delete is capped at 10,000 rows; repeat it, or use Batch Apex, if you have
+more than that.
 
 ## Polling intervals
 

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -62,6 +62,11 @@ const (
 	//
 	// See: sdk-specs / SCMP-server-connection-minutes-polling (section 1.1).
 	INSTANCE_ID_HEADER = "X-LaunchDarkly-Instance-Id"
+	// PROJECT_HEADER names the LaunchDarkly project on Salesforce-bound requests, so the
+	// org can scope stored flag data and queued events to one project. It is sent only
+	// when LD_PROJECT_KEY is configured, which keeps a bridge that has not opted in
+	// indistinguishable from one running an older version.
+	PROJECT_HEADER = "LD-Project-Key"
 )
 
 type Bridge struct {
@@ -81,6 +86,10 @@ type Bridge struct {
 	// LaunchDarkly-bound request (see INSTANCE_ID_HEADER) so the platform can estimate
 	// server-connection-minutes for polling clients.
 	instanceID string
+	// projectKey scopes this bridge to one LaunchDarkly project within the Salesforce org.
+	// Empty means unscoped, matching records that carry no project. It must agree with the
+	// project key configured on the Apex side or evaluation finds no flag data.
+	projectKey string
 	// eventPollInterval is how long eventLoop waits between drains of EventData__c,
 	// and flagPollInterval is how long featureLoop waits between flag polls. Both
 	// default to DEFAULT_POLL_INTERVAL and are configurable per loop.
@@ -212,6 +221,19 @@ func newBridge() (*Bridge, error) {
 
 	bridge.client = http.Client{
 		Timeout: httpTimeoutDuration,
+	}
+
+	// Optional. Unset means this bridge owns the records that carry no project, which is
+	// both the pre-multi-project behavior and the state an existing deployment upgrades
+	// into without changing anything. Logged either way, because a mismatch against the
+	// Apex-side project key produces no error -- evaluation simply finds no flag data and
+	// every variation returns its fallback.
+	bridge.projectKey = strings.TrimSpace(os.Getenv("LD_PROJECT_KEY"))
+	if bridge.projectKey == "" {
+		log.Print("LD_PROJECT_KEY is not set, scoping to records with no project")
+	} else {
+		log.Printf("LD_PROJECT_KEY is %q; the Apex client must be configured with the same value",
+			bridge.projectKey)
 	}
 
 	context, cancel := context.WithCancel(context.Background())
@@ -346,6 +368,14 @@ func (bridge *Bridge) requestWithOauth(request *http.Request) (*http.Response, e
 	bridge.lock.Unlock()
 
 	request.Header.Set("Authorization", "Bearer "+token)
+
+	// Every Salesforce-bound request goes through this function, so the project is stamped
+	// here rather than at each call site. When unset the header is omitted entirely, so the
+	// request is indistinguishable from one sent by a bridge predating multi-project
+	// support -- which is what makes either upgrade order safe.
+	if bridge.projectKey != "" {
+		request.Header.Set(PROJECT_HEADER, bridge.projectKey)
+	}
 
 	response, err := bridge.client.Do(request)
 	if err != nil {

--- a/bridge/main_test.go
+++ b/bridge/main_test.go
@@ -199,7 +199,7 @@ func setMinimalBridgeEnv(t *testing.T) {
 	setEnv(t, "OAUTH_USERNAME", "test@example.invalid")
 	setEnv(t, "OAUTH_PASSWORD", "test-password")
 	setEnv(t, "OAUTH_SECRET", "test-secret")
-	for _, name := range []string{"OAUTH_JWT_KEY", "OAUTH_URI", "HTTP_TIMEOUT", "LD_BASE_URI", "LD_EVENTS_URI"} {
+	for _, name := range []string{"OAUTH_JWT_KEY", "OAUTH_URI", "HTTP_TIMEOUT", "LD_BASE_URI", "LD_EVENTS_URI", "LD_PROJECT_KEY"} {
 		unsetEnv(t, name)
 	}
 }
@@ -785,22 +785,43 @@ func TestSalesforceRequestsCarryProjectHeader(t *testing.T) {
 	}
 }
 
-// TestProjectKeyIsTrimmedAndOptional pins the env-var handling: surrounding whitespace is not
-// part of the key, and an all-whitespace value means unset rather than a key of spaces.
-func TestProjectKeyIsTrimmedAndOptional(t *testing.T) {
-	for _, testCase := range []struct {
-		name string
-		set  string
-		want string
+// TestNewBridgeResolvesProjectKey covers LD_PROJECT_KEY through newBridge rather than by
+// reading the variable back directly, so the trimming and the optionality are asserted on the
+// value the bridge actually uses.
+//
+// The distinction between unset and whitespace-only matters: both must yield an empty key,
+// because an empty key is what causes the project header to be omitted entirely, and that
+// omission is what lets an org and a bridge be upgraded in either order.
+func TestNewBridgeResolvesProjectKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		set   bool
+		want  string
 	}{
-		{name: "plain", set: "gps", want: "gps"},
-		{name: "padded", set: "  gps  ", want: "gps"},
-		{name: "whitespace only", set: "   ", want: ""},
-	} {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Setenv("LD_PROJECT_KEY", testCase.set)
-			if got := strings.TrimSpace(os.Getenv("LD_PROJECT_KEY")); got != testCase.want {
-				t.Errorf("LD_PROJECT_KEY resolved to %q, want %q", got, testCase.want)
+		{name: "unset yields no project", set: false, want: ""},
+		{name: "empty yields no project", value: "", set: true, want: ""},
+		{name: "whitespace only yields no project", value: "   ", set: true, want: ""},
+		{name: "plain value", value: "gps", set: true, want: "gps"},
+		{name: "surrounding whitespace is trimmed", value: "  gps  ", set: true, want: "gps"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			setMinimalBridgeEnv(t)
+			if test.set {
+				setEnv(t, "LD_PROJECT_KEY", test.value)
+			} else {
+				unsetEnv(t, "LD_PROJECT_KEY")
+			}
+
+			bridge, err := newBridge()
+			if err != nil {
+				t.Fatalf("newBridge returned unexpected error: %v", err)
+			}
+			if bridge.projectKey != test.want {
+				t.Errorf("projectKey = %q, want %q", bridge.projectKey, test.want)
 			}
 		})
 	}

--- a/bridge/main_test.go
+++ b/bridge/main_test.go
@@ -736,3 +736,72 @@ func TestEventLoopReusesConnectionsOnPollError(t *testing.T) {
 			connections, served, allowedConnections)
 	}
 }
+
+// TestSalesforceRequestsCarryProjectHeader covers both directions of the multi-project
+// contract on the bridge side: the header rides Salesforce-bound requests when a project is
+// configured, and is absent entirely when one is not.
+//
+// The absence half matters as much as the presence half. An omitted header is what makes a
+// bridge that has not opted in indistinguishable from one running an older version, which is
+// what lets an operator upgrade the org and the bridge in either order.
+func TestSalesforceRequestsCarryProjectHeader(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		projectKey string
+		want       string
+	}{
+		{name: "configured", projectKey: "gps", want: "gps"},
+		{name: "unset", projectKey: "", want: ""},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var captured string
+			var present bool
+
+			bridge := newTestBridge(t, "http://unused.invalid", "http://unused.invalid")
+			bridge.oauthCurrentToken = "test-token"
+			bridge.projectKey = testCase.projectKey
+
+			sfServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured = r.Header.Get(PROJECT_HEADER)
+				_, present = r.Header[PROJECT_HEADER]
+				bridge.cancel()
+				_, _ = w.Write([]byte(`[]`))
+			}))
+			defer sfServer.Close()
+			bridge.salesforceURL = sfServer.URL + "/"
+
+			if err := bridge.eventLoop(); err != nil {
+				t.Fatalf("eventLoop returned unexpected error: %v", err)
+			}
+
+			if captured != testCase.want {
+				t.Errorf("%s = %q, want %q", PROJECT_HEADER, captured, testCase.want)
+			}
+			if testCase.projectKey == "" && present {
+				t.Errorf("%s was sent with an unset project key; it must be omitted so the "+
+					"request is indistinguishable from an older bridge's", PROJECT_HEADER)
+			}
+		})
+	}
+}
+
+// TestProjectKeyIsTrimmedAndOptional pins the env-var handling: surrounding whitespace is not
+// part of the key, and an all-whitespace value means unset rather than a key of spaces.
+func TestProjectKeyIsTrimmedAndOptional(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		set  string
+		want string
+	}{
+		{name: "plain", set: "gps", want: "gps"},
+		{name: "padded", set: "  gps  ", want: "gps"},
+		{name: "whitespace only", set: "   ", want: ""},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("LD_PROJECT_KEY", testCase.set)
+			if got := strings.TrimSpace(os.Getenv("LD_PROJECT_KEY")); got != testCase.want {
+				t.Errorf("LD_PROJECT_KEY resolved to %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}

--- a/force-app/main/classes/BatchingEventSink.cls
+++ b/force-app/main/classes/BatchingEventSink.cls
@@ -2,11 +2,21 @@ public class BatchingEventSink implements EventSinkInterface {
   List<EventData__c> events;
   Integer maxEvents;
 
+  // The project events written by this sink belong to. The cap here is an in-memory
+  // counter scoped to this instance, so it needs no query to stay per-project.
+  private final String project;
+
+  // Retained so existing callers keep compiling.
   public BatchingEventSink(Integer maxEvents) {
+    this(maxEvents, null);
+  }
+
+  public BatchingEventSink(Integer maxEvents, String project) {
     System.assertNotEquals(maxEvents, null);
 
     this.maxEvents = maxEvents;
     this.events = new List<EventData__c>();
+    this.project = project;
   }
 
   public void sinkIdentify(LDEvent.Identify event) {
@@ -33,6 +43,7 @@ public class BatchingEventSink implements EventSinkInterface {
     EventData__c record = new EventData__c();
     record.Kind__c = kind;
     record.Raw__c = raw;
+    record.Project__c = this.project;
 
     this.events.add(record);
   }

--- a/force-app/main/classes/CachingDataStore.cls
+++ b/force-app/main/classes/CachingDataStore.cls
@@ -7,13 +7,23 @@ public class CachingDataStore implements DataStoreInterface {
   private final Integer ttl;
   private Long cachedAt;
 
+  // Refer to the note in DataStore: bound here, not per call, so Evaluator's prerequisite
+  // and segment lookups stay inside one project.
+  private final String project;
+
+  // Retained so existing callers keep compiling.
   public CachingDataStore(Integer ttl, GetTimeInterface getTime) {
+    this(ttl, getTime, null);
+  }
+
+  public CachingDataStore(Integer ttl, GetTimeInterface getTime, String project) {
     System.assertNotEquals(ttl, null);
 
     this.getTime = getTime;
 
     this.ttl = ttl;
     this.cachedAt = null;
+    this.project = project;
   }
 
   private void loadCache() {
@@ -32,6 +42,7 @@ public class CachingDataStore implements DataStoreInterface {
     List<VersionedData__c> versionedData = [
       SELECT Version__c, Raw__c, Key__c, Kind__c
       FROM VersionedData__c
+      WHERE Project__c = :project
     ];
 
     for (VersionedData__C datum : versionedData) {
@@ -55,7 +66,7 @@ public class CachingDataStore implements DataStoreInterface {
     List<VersionedData__c> versioned = [
       SELECT Version__c, Raw__c, Key__c, Kind__c
       FROM VersionedData__c
-      WHERE Key__c = :key AND Kind__c = :kind
+      WHERE Key__c = :key AND Kind__c = :kind AND Project__c = :project
       LIMIT 1
     ];
 
@@ -82,8 +93,13 @@ public class CachingDataStore implements DataStoreInterface {
   }
 
   public void putAll(Map<String, Object> kinds) {
-    // delete existing store values
-    List<VersionedData__c> existingFeatures = [SELECT Key__c FROM VersionedData__C];
+    // Delete only this project's store values. An unscoped delete here would wipe every
+    // other project's flag data on every push.
+    List<VersionedData__c> existingFeatures = [
+      SELECT Key__c
+      FROM VersionedData__c
+      WHERE Project__c = :project
+    ];
     delete existingFeatures;
 
     // iterate over kinds of features such as flags / segments
@@ -92,7 +108,7 @@ public class CachingDataStore implements DataStoreInterface {
 
       for (String key : features.keySet()) {
         Map<String, Object> feature = (Map<String, Object>) features.get(key);
-        VersionedData versioned = new VersionedData(kind, feature);
+        VersionedData versioned = new VersionedData(kind, feature, this.project);
 
         this.insertVersionedData(versioned);
       }

--- a/force-app/main/classes/DataStore.cls
+++ b/force-app/main/classes/DataStore.cls
@@ -1,12 +1,27 @@
 public class DataStore implements DataStoreInterface {
+  // The LaunchDarkly project this store is scoped to. Null scopes it to records with no
+  // project, which is what an org looks like before multi-project support and what a
+  // bridge running without a project key continues to write.
+  //
+  // The project is bound here rather than passed per call so that every path through
+  // Evaluator -- including prerequisite and segment lookups, which are made by key alone
+  // -- stays within one project without Evaluator needing to know projects exist.
+  private final String project;
+
+  // Retained so existing callers keep compiling.
   public DataStore() {
+    this(null);
+  }
+
+  public DataStore(String project) {
+    this.project = project;
   }
 
   public VersionedData__C getVersioned(String key, String kind) {
     List<VersionedData__c> versioned = [
       SELECT Version__c, Raw__c, Key__c, Kind__c
       FROM VersionedData__c
-      WHERE Key__c = :key AND Kind__c = :kind
+      WHERE Key__c = :key AND Kind__c = :kind AND Project__c = :project
       LIMIT 1
     ];
 
@@ -43,7 +58,7 @@ public class DataStore implements DataStoreInterface {
     List<VersionedData__c> flags = [
       SELECT Version__c, Raw__c, Key__c, Kind__c
       FROM VersionedData__c
-      WHERE Kind__c = 'flags'
+      WHERE Kind__c = 'flags' AND Project__c = :project
     ];
 
     for (VersionedData__C flag : flags) {
@@ -58,8 +73,9 @@ public class DataStore implements DataStoreInterface {
   }
 
   public void putAll(Map<String, Object> kinds) {
-    // delete existing store values
-    delete [SELECT Key__c FROM VersionedData__c];
+    // Delete only this project's store values. An unscoped delete here would wipe every
+    // other project's flag data on every push.
+    delete [SELECT Key__c FROM VersionedData__c WHERE Project__c = :project];
 
     List<VersionedData__c> versionData = new List<VersionedData__c>();
 
@@ -70,7 +86,7 @@ public class DataStore implements DataStoreInterface {
       for (String key : features.keySet()) {
         Map<String, Object> feature = (Map<String, Object>) features.get(key);
 
-        VersionedData versioned = new VersionedData(kind, feature);
+        VersionedData versioned = new VersionedData(kind, feature, this.project);
 
         versionData.add(versioned.getSObject());
       }

--- a/force-app/main/classes/EventREST.cls
+++ b/force-app/main/classes/EventREST.cls
@@ -1,15 +1,34 @@
 @RestResource(urlMapping='/event')
 global with sharing class EventREST {
+  // The bridge names its project in a header rather than the body or the URL. A header is
+  // invisible to a bridge or an org that predates multi-project support, so old and new
+  // versions of each side interoperate in either upgrade order.
+  public static final String PROJECT_HEADER = 'LD-Project-Key';
+
   @HttpGet
   global static void doGet() {
     RestContext.response.addHeader('Content-Type', 'application/json');
-    RestContext.response.responseBody = Blob.valueOf(JSON.serialize(EventREST.prepareEvents()));
+    RestContext.response.responseBody = Blob.valueOf(
+      JSON.serialize(EventREST.prepareEvents(ProjectHeader.read(RestContext.request, PROJECT_HEADER)))
+    );
   }
 
+  // Retained so existing callers keep compiling.
   public static Object prepareEvents() {
+    return prepareEvents(null);
+  }
+
+  public static Object prepareEvents(String project) {
     EventProcessor processor = new EventProcessor(new GetTimeImpl());
 
-    List<EventData__c> events = [SELECT Kind__c, Raw__c FROM EventData__c];
+    // Scoped so a bridge only ever drains and deletes its own project's events. An
+    // unscoped drain delivers another project's events to this bridge's environment under
+    // this bridge's SDK key, and those events carry user attributes.
+    List<EventData__c> events = [
+      SELECT Kind__c, Raw__c
+      FROM EventData__c
+      WHERE Project__c = :project
+    ];
 
     for (EventData__c event : events) {
       switch on event.Kind__c {

--- a/force-app/main/classes/EventSink.cls
+++ b/force-app/main/classes/EventSink.cls
@@ -1,10 +1,19 @@
 public class EventSink implements EventSinkInterface {
   Integer maxEvents;
 
+  // The project events written by this sink belong to, and the scope of the queue cap.
+  private final String project;
+
+  // Retained so existing callers keep compiling.
   public EventSink(Integer maxEvents) {
+    this(maxEvents, null);
+  }
+
+  public EventSink(Integer maxEvents, String project) {
     System.assertNotEquals(maxEvents, null);
 
     this.maxEvents = maxEvents;
+    this.project = project;
   }
 
   public void sinkIdentify(LDEvent.Identify event) {
@@ -24,7 +33,10 @@ public class EventSink implements EventSinkInterface {
   }
 
   public void sinkGeneric(String kind, String raw) {
-    Integer count = [SELECT COUNT() FROM EventData__c];
+    // Scoped to this project so maxEventsInQueue is a per-project cap. An unscoped count
+    // lets another project's undrained events -- including rows orphaned by a
+    // decommissioned bridge -- silently stop this project from recording events at all.
+    Integer count = [SELECT COUNT() FROM EventData__c WHERE Project__c = :project];
 
     if (count >= this.maxEvents) {
       return;
@@ -33,6 +45,7 @@ public class EventSink implements EventSinkInterface {
     EventData__c record = new EventData__c();
     record.Kind__c = kind;
     record.Raw__c = raw;
+    record.Project__c = this.project;
 
     insert record;
   }

--- a/force-app/main/classes/LDClient.cls
+++ b/force-app/main/classes/LDClient.cls
@@ -31,16 +31,18 @@ public class LDClient {
     }
 
     this.getTime = new GetTimeImpl();
+    String projectKey = this.config.getProjectKey();
+
     if (config.getCacheTtl() != null) {
-      this.store = new CachingDataStore(config.getCacheTtl(), this.getTime);
+      this.store = new CachingDataStore(config.getCacheTtl(), this.getTime, projectKey);
     } else {
-      this.store = new DataStore();
+      this.store = new DataStore(projectKey);
     }
 
     if (config.getBatchEvents()) {
-      this.eventSink = new BatchingEventSink(this.config.getMaxEventsInQueue());
+      this.eventSink = new BatchingEventSink(this.config.getMaxEventsInQueue(), projectKey);
     } else {
-      this.eventSink = new EventSink(this.config.getMaxEventsInQueue());
+      this.eventSink = new EventSink(this.config.getMaxEventsInQueue(), projectKey);
     }
 
     this.evaluator = new Evaluator(this.store, this.getTime);

--- a/force-app/main/classes/LDConfig.cls
+++ b/force-app/main/classes/LDConfig.cls
@@ -3,12 +3,20 @@ public class LDConfig {
   private final Integer maxEvents;
   private final Integer ttl;
   private final Boolean batchEvents;
+  private final String projectKey;
 
-  private LDConfig(Boolean allAttributesPrivate, Integer maxEvents, Integer ttl, Boolean batchEvents) {
+  private LDConfig(
+    Boolean allAttributesPrivate,
+    Integer maxEvents,
+    Integer ttl,
+    Boolean batchEvents,
+    String projectKey
+  ) {
     this.allAttributesPrivate = allAttributesPrivate;
     this.maxEvents = maxEvents;
     this.ttl = ttl;
     this.batchEvents = batchEvents;
+    this.projectKey = projectKey;
   }
 
   public Boolean getAllAttributesPrivate() {
@@ -27,17 +35,23 @@ public class LDConfig {
     return this.batchEvents;
   }
 
+  public String getProjectKey() {
+    return this.projectKey;
+  }
+
   public class Builder {
     private Boolean allAttributesPrivate;
     private Integer maxEvents;
     private Integer ttl;
     private Boolean batchEvents;
+    private String projectKey;
 
     public Builder() {
       this.allAttributesPrivate = false;
       this.maxEvents = 1000;
       this.ttl = null;
       this.batchEvents = false;
+      this.projectKey = null;
     }
 
     public Builder setAllAttributesPrivate(Boolean allAttributesPrivate) {
@@ -70,8 +84,23 @@ public class LDConfig {
       return this;
     }
 
+    // The LaunchDarkly project this client reads and writes. It must match the project key
+    // configured on the bridge that populates this org, or evaluation finds no flag data and
+    // every variation call returns its fallback. Leaving it unset scopes the client to
+    // records carrying no project, which is the pre-multi-project behavior.
+    public Builder setProjectKey(String projectKey) {
+      this.projectKey = projectKey;
+      return this;
+    }
+
     public LDConfig build() {
-      return new LDConfig(this.allAttributesPrivate, this.maxEvents, this.ttl, this.batchEvents);
+      return new LDConfig(
+        this.allAttributesPrivate,
+        this.maxEvents,
+        this.ttl,
+        this.batchEvents,
+        this.projectKey
+      );
     }
   }
 }

--- a/force-app/main/classes/ProjectHeader.cls
+++ b/force-app/main/classes/ProjectHeader.cls
@@ -1,0 +1,32 @@
+// Reads the LaunchDarkly project key from an inbound Apex REST request.
+//
+// The project travels as a header rather than in the body or the URL. The bridge forwards
+// LaunchDarkly's flag payload verbatim, and DataStore.putAll treats every top-level key of
+// that payload as a kind and casts its value to a Map, so adding a sibling key would throw
+// in any org running an older version of this SDK. A header is ignored by older orgs and
+// omitted by older bridges, so the two sides can be upgraded in either order.
+public class ProjectHeader {
+  // RestRequest.headers is a plain Map with case-sensitive lookup, while HTTP header names
+  // are case-insensitive and intermediaries are free to change their casing. Scan instead
+  // of indexing so a differently-cased header is still found.
+  public static String read(RestRequest request, String name) {
+    if (request == null || request.headers == null || name == null) {
+      return null;
+    }
+
+    for (String header : request.headers.keySet()) {
+      if (header != null && header.equalsIgnoreCase(name)) {
+        String value = request.headers.get(header);
+
+        // An absent project and an empty one mean the same thing: records with no project.
+        if (String.isBlank(value)) {
+          return null;
+        }
+
+        return value.trim();
+      }
+    }
+
+    return null;
+  }
+}

--- a/force-app/main/classes/ProjectHeader.cls-meta.xml
+++ b/force-app/main/classes/ProjectHeader.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ProjectHeader">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/classes/StoreREST.cls
+++ b/force-app/main/classes/StoreREST.cls
@@ -2,7 +2,9 @@
 global with sharing class StoreREST {
   @HttpGet
   global static String doGet() {
-    LDConfig config = new LDConfig.Builder().build();
+    LDConfig config = new LDConfig.Builder()
+      .setProjectKey(ProjectHeader.read(RestContext.request, EventREST.PROJECT_HEADER))
+      .build();
     LDUser user = new LDUser.Builder('user-key').build();
     LDClient client = new LDClient(config);
 
@@ -19,7 +21,10 @@ global with sharing class StoreREST {
   global static String doPost() {
     RestRequest request = RestContext.request;
 
-    DataStore store = new DataStore();
+    // The project arrives as a header, never as a key in the body: the bridge forwards
+    // LaunchDarkly's payload verbatim and putAll treats every top-level key as a kind,
+    // casting its value to a Map, so a sibling key would throw in older orgs.
+    DataStore store = new DataStore(ProjectHeader.read(request, EventREST.PROJECT_HEADER));
 
     store.putAll((Map<String, Object>) JSON.deserializeUntyped(request.requestBody.tostring()));
 

--- a/force-app/main/classes/VersionedData.cls
+++ b/force-app/main/classes/VersionedData.cls
@@ -3,8 +3,16 @@ public class VersionedData {
   private String key;
   private String kind;
   private String raw;
+  private String project;
 
+  // Retained so existing callers keep compiling. A null project means the record is
+  // not associated with any particular LaunchDarkly project.
   public VersionedData(String kind, Map<String, Object> obj) {
+    this(kind, obj, null);
+  }
+
+  public VersionedData(String kind, Map<String, Object> obj, String project) {
+    this.project = project;
     this.version = (Integer) obj.get('version');
     this.key = (String) obj.get('key');
     this.kind = kind;
@@ -32,12 +40,17 @@ public class VersionedData {
     return this.raw;
   }
 
+  public String getProject() {
+    return this.project;
+  }
+
   public VersionedData__c getSObject() {
     VersionedData__c model = new VersionedData__c();
     model.Key__c = this.key;
     model.Version__c = this.version;
     model.Raw__c = this.raw;
     model.Kind__c = this.kind;
+    model.Project__c = this.project;
 
     return model;
   }

--- a/force-app/main/objects/EventData__c/fields/Project__c.field-meta.xml
+++ b/force-app/main/objects/EventData__c/fields/Project__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Project__c</fullName>
     <description>LaunchDarkly project key this record belongs to. Null means the record predates multi-project support, or the bridge and SDK are running without an explicit project key.</description>
-    <externalId>true</externalId>
+    <externalId>false</externalId>
     <label>LaunchDarkly project</label>
     <required>false</required>
     <trackTrending>false</trackTrending>

--- a/force-app/main/objects/EventData__c/fields/Project__c.field-meta.xml
+++ b/force-app/main/objects/EventData__c/fields/Project__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Project__c</fullName>
+    <description>LaunchDarkly project key this record belongs to. Null means the record predates multi-project support, or the bridge and SDK are running without an explicit project key.</description>
+    <externalId>true</externalId>
+    <label>LaunchDarkly project</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <length>255</length>
+</CustomField>

--- a/force-app/main/objects/VersionedData__c/fields/Key__c.field-meta.xml
+++ b/force-app/main/objects/VersionedData__c/fields/Key__c.field-meta.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Key__c</fullName>
-    <externalId>false</externalId>
+    <description>Flag or segment key. Marked as an External ID to obtain an index: a key is close to unique within a project, so it is the one filter on this object selective enough for the query optimizer to use. A project filter matches roughly one over the number of projects of the table and is not selective enough to benefit.</description>
+    <externalId>true</externalId>
     <label>Flag Key</label>
     <required>true</required>
     <trackTrending>false</trackTrending>

--- a/force-app/main/objects/VersionedData__c/fields/Project__c.field-meta.xml
+++ b/force-app/main/objects/VersionedData__c/fields/Project__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Project__c</fullName>
     <description>LaunchDarkly project key this record belongs to. Null means the record predates multi-project support, or the bridge and SDK are running without an explicit project key.</description>
-    <externalId>true</externalId>
+    <externalId>false</externalId>
     <label>LaunchDarkly project</label>
     <required>false</required>
     <trackTrending>false</trackTrending>

--- a/force-app/main/objects/VersionedData__c/fields/Project__c.field-meta.xml
+++ b/force-app/main/objects/VersionedData__c/fields/Project__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Project__c</fullName>
+    <description>LaunchDarkly project key this record belongs to. Null means the record predates multi-project support, or the bridge and SDK are running without an explicit project key.</description>
+    <externalId>true</externalId>
+    <label>LaunchDarkly project</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <length>255</length>
+</CustomField>

--- a/force-app/test/MultiProjectIsolationTest.cls
+++ b/force-app/test/MultiProjectIsolationTest.cls
@@ -1,0 +1,204 @@
+// Pins the invariant that one project's data is never visible to, drained by, or deleted by
+// another's.
+//
+// This exists as one behavioural suite rather than as assertions bolted onto each store and
+// sink test on purpose. Scoping is applied at a dozen separate query sites, and a single
+// missed filter is a silent correctness bug -- during implementation one site was already
+// missed by a careful manual grep, because CachingDataStore spells the type VersionedData__C
+// with a capital C. Tests that assert the observable property catch a missed filter at any
+// site, including sites that do not exist yet.
+//
+// Every fixture below deliberately uses the SAME flag and segment keys in both projects.
+// Keys are not unique across LaunchDarkly projects, so colliding keys are the normal case,
+// and getVersioned ends in LIMIT 1 -- an unscoped lookup returns an arbitrary project's row.
+@isTest
+private class MultiProjectIsolationTest {
+  private static final String ALPHA = 'alpha';
+  private static final String BETA = 'beta';
+
+  // Same key, different version, so the version identifies which project a row came from.
+  //
+  // The flag is spelled out in full rather than as just a key and version. A minimal object
+  // round-trips through getVersioned but throws inside DataModel.Flag, which allFlags swallows
+  // and getFlag propagates -- so an under-specified fixture reads as a scoping failure.
+  private static String flagPayload(Integer version) {
+    return '{"flags":{"shared":{"version":' + version + ',"key":"shared","on":false,' +
+      '"variations":[true],"offVariation":0,"fallthrough":{"variation":0},' +
+      '"prerequisites":[],"targets":[],"rules":[],"salt":"s"}},"segments":{}}';
+  }
+
+  private static String segmentPayload(Integer version) {
+    return '{"flags":{},"segments":{"shared":{"version":' + version + ',"key":"shared"}}}';
+  }
+
+  private static Map<String, Object> parse(String payload) {
+    return (Map<String, Object>) JSON.deserializeUntyped(payload);
+  }
+
+  @isTest
+  static void flagsAreIsolatedByProject() {
+    new DataStore(ALPHA).putAll(parse(flagPayload(1)));
+    new DataStore(BETA).putAll(parse(flagPayload(2)));
+
+    System.assertEquals(1, new DataStore(ALPHA).getVersioned('shared', 'flags').Version__c);
+    System.assertEquals(2, new DataStore(BETA).getVersioned('shared', 'flags').Version__c);
+
+    System.assertEquals(1, new DataStore(ALPHA).allFlags().size());
+    System.assertEquals(1, new DataStore(BETA).allFlags().size());
+  }
+
+  @isTest
+  static void putAllOnlyDeletesItsOwnProject() {
+    new DataStore(ALPHA).putAll(parse(flagPayload(1)));
+    new DataStore(BETA).putAll(parse(flagPayload(2)));
+
+    // An unscoped delete here is the failure that makes two bridges destroy each other's
+    // flag data on every push.
+    new DataStore(ALPHA).putAll(parse('{}'));
+
+    System.assertEquals(null, new DataStore(ALPHA).getFlag('shared'));
+    System.assertNotEquals(null, new DataStore(BETA).getFlag('shared'));
+  }
+
+  @isTest
+  static void legacyNullProjectIsItsOwnScope() {
+    // What an org looks like before multi-project support, and what a bridge without a
+    // project key keeps writing during a migration.
+    new DataStore().putAll(parse(flagPayload(9)));
+    new DataStore(ALPHA).putAll(parse(flagPayload(1)));
+
+    System.assertEquals(9, new DataStore().getVersioned('shared', 'flags').Version__c);
+    System.assertEquals(1, new DataStore(ALPHA).getVersioned('shared', 'flags').Version__c);
+
+    // The named project's push must not disturb the legacy rows still serving old clients.
+    new DataStore(ALPHA).putAll(parse('{}'));
+    System.assertNotEquals(null, new DataStore().getFlag('shared'));
+  }
+
+  @isTest
+  static void cachingStoreIsolatesByProject() {
+    new DataStore(ALPHA).putAll(parse(flagPayload(1)));
+    new DataStore(BETA).putAll(parse(flagPayload(2)));
+
+    CachingDataStore alphaStore = new CachingDataStore(60000, new GetTimeMock(), ALPHA);
+    CachingDataStore betaStore = new CachingDataStore(60000, new GetTimeMock(), BETA);
+
+    System.assertEquals(1, alphaStore.allFlags().size());
+    System.assertEquals(1, betaStore.allFlags().size());
+    System.assertEquals(1, alphaStore.getVersioned('shared', 'flags').Version__c);
+    System.assertEquals(2, betaStore.getVersioned('shared', 'flags').Version__c);
+  }
+
+  @isTest
+  static void cachingStorePutAllOnlyDeletesItsOwnProject() {
+    new CachingDataStore(60000, new GetTimeMock(), ALPHA).putAll(parse(flagPayload(1)));
+    new CachingDataStore(60000, new GetTimeMock(), BETA).putAll(parse(flagPayload(2)));
+
+    new CachingDataStore(60000, new GetTimeMock(), ALPHA).putAll(parse('{}'));
+
+    System.assertEquals(null, new DataStore(ALPHA).getFlag('shared'));
+    System.assertNotEquals(null, new DataStore(BETA).getFlag('shared'));
+  }
+
+  @isTest
+  static void segmentsAreIsolatedByProject() {
+    new DataStore(ALPHA).putAll(parse(segmentPayload(1)));
+    new DataStore(BETA).putAll(parse(segmentPayload(2)));
+
+    System.assertEquals(1, new DataStore(ALPHA).getVersioned('shared', 'segments').Version__c);
+    System.assertEquals(2, new DataStore(BETA).getVersioned('shared', 'segments').Version__c);
+  }
+
+  // The subtlest case, and the reason the project is bound to the store rather than passed
+  // per call: Evaluator resolves prerequisites by key alone. A leak here does not produce
+  // missing data, it produces a confidently wrong answer.
+  //
+  // Both projects hold an identical 'gated' flag whose prerequisite is 'prereq'. Alpha's
+  // prereq is on and serves the required variation, so 'gated' falls through to true.
+  // Beta's prereq is off, which fails the prerequisite regardless of variation, so 'gated'
+  // returns its off variation, false.
+  private static final String GATED =
+    '{"version":1,"key":"gated","on":true,"variations":[false,true],' +
+    '"offVariation":0,"fallthrough":{"variation":1},' +
+    '"prerequisites":[{"key":"prereq","variation":0}],"targets":[],"rules":[],"salt":"s"}';
+
+  private static String prereqFlag(Boolean prereqIsOn) {
+    return '{"version":1,"key":"prereq","on":' + (prereqIsOn ? 'true' : 'false') +
+      ',"variations":[true],"offVariation":0,"fallthrough":{"variation":0},' +
+      '"prerequisites":[],"targets":[],"rules":[],"salt":"s"}';
+  }
+
+  private static String gatedPayload(Boolean prereqIsOn) {
+    return '{"flags":{"gated":' + GATED + ',"prereq":' + prereqFlag(prereqIsOn) + '},"segments":{}}';
+  }
+
+  @isTest
+  static void prerequisiteResolvesWithinProject() {
+    new DataStore(ALPHA).putAll(parse(gatedPayload(true)));
+    new DataStore(BETA).putAll(parse(gatedPayload(false)));
+
+    LDUser user = new LDUser.Builder('user-key').build();
+
+    LDClient alphaClient = new LDClient(new LDConfig.Builder().setProjectKey(ALPHA).build());
+    LDClient betaClient = new LDClient(new LDConfig.Builder().setProjectKey(BETA).build());
+
+    System.assertEquals(true, alphaClient.boolVariation(user, 'gated', false));
+    System.assertEquals(false, betaClient.boolVariation(user, 'gated', true));
+  }
+
+  @isTest
+  static void eventDrainIsolatesByProject() {
+    insert new List<EventData__c>{
+      new EventData__c(Kind__c = 'identify', Raw__c = '{}', Project__c = ALPHA),
+      new EventData__c(Kind__c = 'identify', Raw__c = '{}', Project__c = BETA),
+      new EventData__c(Kind__c = 'identify', Raw__c = '{}', Project__c = null)
+    };
+
+    // An unscoped drain delivers another project's events to this bridge's environment
+    // under this bridge's SDK key, and those events carry user attributes.
+    EventREST.prepareEvents(ALPHA);
+
+    System.assertEquals(0, [SELECT COUNT() FROM EventData__c WHERE Project__c = :ALPHA]);
+    System.assertEquals(1, [SELECT COUNT() FROM EventData__c WHERE Project__c = :BETA]);
+    System.assertEquals(1, [SELECT COUNT() FROM EventData__c WHERE Project__c = null]);
+  }
+
+  @isTest
+  static void eventQueueCapIsScopedByProject() {
+    EventSink alphaSink = new EventSink(2, ALPHA);
+    alphaSink.sinkGeneric('identify', '{}');
+    alphaSink.sinkGeneric('identify', '{}');
+    alphaSink.sinkGeneric('identify', '{}');
+
+    System.assertEquals(2, [SELECT COUNT() FROM EventData__c WHERE Project__c = :ALPHA]);
+
+    // Alpha being at its cap must not stop beta recording. With an unscoped count, another
+    // project's undrained events silently stop this one from recording anything at all.
+    EventSink betaSink = new EventSink(2, BETA);
+    betaSink.sinkGeneric('identify', '{}');
+
+    System.assertEquals(1, [SELECT COUNT() FROM EventData__c WHERE Project__c = :BETA]);
+  }
+
+  @isTest
+  static void batchingSinkStampsProject() {
+    BatchingEventSink sink = new BatchingEventSink(10, ALPHA);
+    sink.sinkGeneric('identify', '{}');
+    sink.close();
+
+    System.assertEquals(1, [SELECT COUNT() FROM EventData__c WHERE Project__c = :ALPHA]);
+  }
+
+  @isTest
+  static void headerReadIsCaseInsensitiveAndTreatsBlankAsUnset() {
+    RestRequest request = new RestRequest();
+    request.headers.put('ld-project-key', ALPHA);
+    System.assertEquals(ALPHA, ProjectHeader.read(request, EventREST.PROJECT_HEADER));
+
+    RestRequest blank = new RestRequest();
+    blank.headers.put(EventREST.PROJECT_HEADER, '   ');
+    System.assertEquals(null, ProjectHeader.read(blank, EventREST.PROJECT_HEADER));
+
+    System.assertEquals(null, ProjectHeader.read(new RestRequest(), EventREST.PROJECT_HEADER));
+  }
+}

--- a/force-app/test/MultiProjectIsolationTest.cls-meta.xml
+++ b/force-app/test/MultiProjectIsolationTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="MultiProjectIsolationTest">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
A single Salesforce org could only ever serve one LaunchDarkly project,
because nothing tied a stored flag to a project. Customers wanting to
segregate flags across separate consoles need a project per console.

Add an optional Project__c field to VersionedData__c and EventData__c and
scope every read, write and delete to it. EventData__c needs it as much as
VersionedData__c does: events must route back to the project they came
from, and they carry user attributes.

The project is bound when a store is constructed rather than passed to each
query. Evaluator resolves prerequisites and segments through the store by
key alone, and keys are not unique across projects, so an unscoped store
lets a prerequisite in one project resolve against another project's flag of
the same key. That is a confidently wrong answer rather than missing data.
Binding at construction scopes every path through Evaluator without changing
DataStoreInterface or Evaluator at all.

Null is the unset value rather than a sentinel string. SOQL binds a null
variable with IS NULL semantics, so one query shape serves both the unset
and named cases with no branching, and an org that has never configured a
project keeps working unchanged. A sentinel would match nothing against
existing records and silently fall back on every evaluation.

Two of the twelve scoped sites deserve calling out. EventSink enforced
maxEventsInQueue with an unscoped count, so one project's undrained events
could reach the cap and silently stop every other project from recording
events at all; it is now a per-project cap. And both stores' putAll opened
with an unscoped delete, which would have made two bridges destroy each
other's flag data on every push.

The project arrives over REST as an LD-Project-Key header rather than in the
body. The bridge forwards LaunchDarkly's payload verbatim and putAll treats
every top-level key as a kind, casting its value to a Map, so a sibling key
would throw in an org running an older version of this SDK. A header is
ignored by older orgs and omitted by older bridges, so the two sides can be
upgraded in either order. RestRequest.headers is case-sensitive while HTTP
header names are not, so ProjectHeader scans rather than indexes.

Existing constructors are retained throughout and default the project to
null, so this is additive: customer Apex calling new DataStore() or
new EventSink(1000) keeps compiling.

MultiProjectIsolationTest asserts the observable property rather than
reviewing each filter, because a single missed filter is a silent
correctness bug. During implementation one site was already missed by a
careful manual grep, since CachingDataStore spells the type VersionedData__C
with a capital C. Every fixture uses the same keys in both projects, which
is the normal case. Verified by unscoping that delete again: the suite fails.

Refs SDK-2953.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Lets one Salesforce org hold flag data and events for more than one LaunchDarkly project. The bridge and Apex client now share an optional project key (`LD_PROJECT_KEY` / `LDConfig.setProjectKey`); unset keeps the previous “no project” scope so existing deployments do not change.
> 
> Stores, sinks, and REST drains stamp and filter on a new `Project__c` field. The project is bound at store construction so Evaluator prerequisite/segment lookups stay in-project without interface changes. `putAll` deletes and `maxEventsInQueue` are per-project so two bridges cannot wipe or starve each other.
> 
> The key travels as an `LD-Project-Key` header (omitted when unset) so old and new bridges/orgs can be upgraded in either order. `VersionedData__c.Key__c` is marked External ID for query selectivity. Isolation is covered by `MultiProjectIsolationTest`; the README documents a zero-downtime migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a1aac09cce24a1b2be34b59ca13e65f6d30adb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->