### PR TITLE
feat: Support the OAuth client credentials flow in the bridge

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -4,8 +4,9 @@ This daemon is used to ensure LaunchDarkly and the Salesforce SDK stay synchroni
 
 ## Configuration
 
-The daemon uses environment variables for configuration. You must configure either the JWT or password based authentication.
-JWT authentication is recommended but password authentication is easier for testing.
+The daemon uses environment variables for configuration. Refer to
+[Authentication](#authentication) for choosing a flow; **client credentials** is the one to
+prefer for a new deployment.
 
 ```bash
 # The secrets in this example are randomly generated
@@ -17,16 +18,26 @@ export SALESFORCE_URL='Your Salesforce Apex REST URL'
 # such as: 'https://na123.salesforce.com/services/apexrest/'
 export OAUTH_ID='Your Salesforce OAuth Id'
 # such as: 'BfBGjyY0.8XTDtB6enx5WXSATZ6mhPhnn.V2xK2Q8aYIW7KBS4r.7RA5QDbhaVOc4swvGZUqao-4X2S6Z-MdP'
+
+# which OAuth flow to use: 'client-credentials', 'jwt-bearer' or 'password'
+export OAUTH_GRANT_TYPE='client-credentials'
+# if not set, the flow is inferred: JWT bearer when OAUTH_JWT_KEY is set, otherwise password
+# client credentials cannot be inferred and must be requested explicitly
+
+# when using client credentials
+export OAUTH_SECRET='Your Salesforce OAuth secret'
+# such as: '1193EEA95E6E26978D5BA60B103CC419FB653E314EA5BF282BDD1D429769685E'
+# no username: the run-as identity is designated on the app in Salesforce
+
+# when using JWT bearer
+export OAUTH_JWT_KEY='Your RSA private key in PEM format base64 encoded'
+# such as: cat private.key | base64 -w 0
 export OAUTH_USERNAME='Your Salesforce username'
 # such as: 'address@example.com'
 
-# when utilizing JWT based auth
-export OAUTH_JWT_KEY='Your RSA private key in PEM format base64 encoded'
-# such as: cat private.key | base64 -w 0
-
-# when utilizing password based auth
+# when using password auth (deprecated)
 export OAUTH_SECRET='Your Salesforce OAuth secret'
-# such as: '1193EEA95E6E26978D5BA60B103CC419FB653E314EA5BF282BDD1D429769685E'
+export OAUTH_USERNAME='Your Salesforce username'
 export OAUTH_PASSWORD='Your Salesforce password + security token'
 # such as: 'mypasswordmysalesforcesecuritytoken'
 
@@ -46,6 +57,51 @@ export FLAG_POLL_INTERVAL='How often to poll LaunchDarkly for flag data'
 # if not set or unparseable, defaults to: '30s'
 # minimum is '30s'; anything shorter is clamped up to '30s'
 ```
+
+## Authentication
+
+Three OAuth flows are supported. Set `OAUTH_GRANT_TYPE` to choose one; the resolved flow is
+logged at startup, which is the quickest way to confirm what the daemon is actually doing.
+
+| Flow | `OAUTH_GRANT_TYPE` | Needs | Use it when |
+| --- | --- | --- | --- |
+| Client credentials | `client-credentials` | `OAUTH_ID`, `OAUTH_SECRET` | Default choice for a new deployment |
+| JWT bearer | `jwt-bearer` | `OAUTH_ID`, `OAUTH_USERNAME`, `OAUTH_JWT_KEY` | You need to act as a specific user, or policy requires a certificate |
+| Password | `password` | `OAUTH_ID`, `OAUTH_SECRET`, `OAUTH_USERNAME`, `OAUTH_PASSWORD` | Deprecated -- avoid |
+
+**Prefer client credentials.** It needs no certificate to generate, upload or rotate, and no
+username -- the run-as identity is designated on the connected app or External Client App in
+Salesforce, so the daemon holds no user credential at all. It also sends no time-bound
+assertion, which makes it indifferent to host clock skew.
+
+That last point is worth knowing if you run the bridge on a VM. The JWT bearer flow signs an
+assertion that expires 120 seconds after it is issued, with no tolerance, so a host whose clock
+has drifted more than two minutes will fail every authentication attempt. There is no
+corresponding failure mode with client credentials.
+
+Enable the flow on the app in Salesforce before configuring it here. On an External Client App
+that is the **Enable Client Credentials Flow** setting, and it requires a run-as user to be
+designated.
+
+**JWT bearer** remains fully supported and is the right choice when the bridge must act as a
+particular Salesforce user, or when your security policy requires certificate-based
+authentication. Note the key must be PKCS#1 -- a PEM block labelled `RSA PRIVATE KEY`. OpenSSL 3
+writes PKCS#8 by default, so generate with `openssl genrsa -traditional` or convert an existing
+key with `openssl rsa -traditional -in old.key -out new.key`.
+
+**Password auth is deprecated.** Salesforce disables the username-password flow by default on
+new orgs and is retiring it, and it requires a security token appended to the password. The
+daemon logs a warning at startup when this flow is selected. It will be removed in a future
+major version.
+
+### Choosing the flow implicitly
+
+`OAUTH_GRANT_TYPE` is optional. When it is unset the flow is inferred from the credentials
+present -- JWT bearer if `OAUTH_JWT_KEY` is set, otherwise password -- which is how the daemon
+behaved before the variable existed, so an existing deployment needs no changes.
+
+Client credentials cannot be inferred, because its credentials are a subset of the password
+flow's. Selecting it always requires setting `OAUTH_GRANT_TYPE`.
 
 ## Polling intervals
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -45,6 +45,9 @@ export OAUTH_PASSWORD='Your Salesforce password + security token'
 export OAUTH_URI='YOUR OAUTH URI'
 # if not set, defaults to: 'https://login.salesforce.com/services/oauth2/token'
 # if authenticating against sandbox, use: 'https://test.salesforce.com/services/oauth2/token'
+# the client credentials grant is not accepted on either of those shared hosts. When that
+# grant is selected and this is unset, the endpoint is derived from SALESFORCE_URL instead,
+# and the derived value is logged at startup
 export HTTP_TIMEOUT='Your timeout'
 # such as: '1500ms'
 # see https://golang.org/pkg/time/#ParseDuration for formatting
@@ -81,7 +84,21 @@ corresponding failure mode with client credentials.
 
 Enable the flow on the app in Salesforce before configuring it here. On an External Client App
 that is the **Enable Client Credentials Flow** setting, and it requires a run-as user to be
-designated.
+designated -- the flow carries no user context, so Salesforce needs to be told which identity
+to act as. Note the setting appears in two places, the app's OAuth settings and its policies,
+and both must be enabled.
+
+This grant is **not accepted on `login.salesforce.com` or `test.salesforce.com`**. Those hosts
+answer `invalid_grant: request not supported on this domain`, which names neither the grant nor
+the setting at fault. Point `OAUTH_URI` at the org's own domain instead:
+
+```bash
+export OAUTH_URI='https://MyDomainName.my.salesforce.com/services/oauth2/token'
+```
+
+Or leave `OAUTH_URI` unset and the bridge derives that endpoint from `SALESFORCE_URL`, logging
+what it chose. Configuring a login host explicitly logs a warning, since the derivation cannot
+override an explicit choice.
 
 **JWT bearer** remains fully supported and is the right choice when the bridge must act as a
 particular Salesforce user, or when your security policy requires certificate-based

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -27,13 +27,27 @@ import (
 )
 
 const (
-	LD_BASE_URI           = "https://sdk.launchdarkly.com"
-	LD_EVENTS_URI         = "https://events.launchdarkly.com"
-	OAUTH_URI             = "https://login.salesforce.com/services/oauth2/token"
-	DEFAULT_POLL_INTERVAL = 30 * time.Second
-	SDK_VERSION           = "1.5.1" // x-release-please-version
-	USER_AGENT            = "ApexServerClient/" + SDK_VERSION
-	HTTP_TIMEOUT          = 30 * time.Second
+	LD_BASE_URI   = "https://sdk.launchdarkly.com"
+	LD_EVENTS_URI = "https://events.launchdarkly.com"
+	OAUTH_URI     = "https://login.salesforce.com/services/oauth2/token"
+	// The OAuth flows the bridge can use to authenticate to Salesforce, as accepted by
+	// OAUTH_GRANT_TYPE.
+	//
+	// GRANT_CLIENT_CREDENTIALS is the one to prefer for a new deployment: it needs no
+	// certificate to generate or rotate, no username -- the run-as identity is designated
+	// on the app in Salesforce -- and it sends no time-bound assertion, so it is
+	// indifferent to host clock skew.
+	//
+	// GRANT_PASSWORD is deprecated. Salesforce disables the username-password flow by
+	// default on new orgs and is retiring it, and it requires a security token appended to
+	// the password.
+	GRANT_JWT_BEARER         = "jwt-bearer"
+	GRANT_CLIENT_CREDENTIALS = "client-credentials"
+	GRANT_PASSWORD           = "password"
+	DEFAULT_POLL_INTERVAL    = 30 * time.Second
+	SDK_VERSION              = "1.5.1" // x-release-please-version
+	USER_AGENT               = "ApexServerClient/" + SDK_VERSION
+	HTTP_TIMEOUT             = 30 * time.Second
 	// MIN_FLAG_POLL_INTERVAL is the shortest FLAG_POLL_INTERVAL the bridge honors,
 	// matching the minimum polling interval used across LaunchDarkly's server SDKs.
 	// A shorter configured value is clamped up to it.
@@ -76,7 +90,9 @@ type Bridge struct {
 	oauthPassword         string
 	oauthCurrentToken     string
 	oauthJWTKey           *rsa.PrivateKey
-	oauthURI              url.URL
+	// oauthGrantType is the resolved OAuth flow, always one of the GRANT_ constants.
+	oauthGrantType string
+	oauthURI       url.URL
 	// instanceID is a v4 UUID generated once per bridge process. It is sent on every
 	// LaunchDarkly-bound request (see INSTANCE_ID_HEADER) so the platform can estimate
 	// server-connection-minutes for polling clients.
@@ -105,6 +121,35 @@ func parseDurationFromEnv(name string, fallback time.Duration) time.Duration {
 	}
 
 	return parsed
+}
+
+// resolveGrantType decides which OAuth flow to use.
+//
+// An explicit OAUTH_GRANT_TYPE always wins. When it is unset the flow is inferred from the
+// credentials present, which is exactly how the bridge behaved before the variable existed:
+// a JWT key means the JWT bearer grant, and its absence means the password grant. That keeps
+// every deployment predating this option working untouched.
+//
+// Inference cannot be extended to the client credentials grant, because its credentials --
+// OAUTH_ID and OAUTH_SECRET -- are a subset of the password grant's. Selecting it therefore
+// requires saying so, which is the reason the variable exists.
+func resolveGrantType(oauthJWTKey string) (string, error) {
+	configured := strings.ToLower(strings.TrimSpace(os.Getenv("OAUTH_GRANT_TYPE")))
+
+	if configured == "" {
+		if oauthJWTKey != "" {
+			return GRANT_JWT_BEARER, nil
+		}
+		return GRANT_PASSWORD, nil
+	}
+
+	switch configured {
+	case GRANT_JWT_BEARER, GRANT_CLIENT_CREDENTIALS, GRANT_PASSWORD:
+		return configured, nil
+	}
+
+	return "", errors.New("OAUTH_GRANT_TYPE '" + configured + "' is not recognized; use " +
+		GRANT_JWT_BEARER + ", " + GRANT_CLIENT_CREDENTIALS + " or " + GRANT_PASSWORD)
 }
 
 func newBridge() (*Bridge, error) {
@@ -147,16 +192,26 @@ func newBridge() (*Bridge, error) {
 	bridge.oauthURI = *oauthURI
 
 	oauthJWTKey := os.Getenv("OAUTH_JWT_KEY")
-	if oauthJWTKey == "" {
-		bridge.oauthPassword = os.Getenv("OAUTH_PASSWORD")
-		if bridge.oauthPassword == "" {
-			return nil, errors.New("OAUTH_PASSWORD not set")
+
+	grantType, err := resolveGrantType(oauthJWTKey)
+	if err != nil {
+		return nil, err
+	}
+	bridge.oauthGrantType = grantType
+	log.Printf("authenticating to Salesforce with the %s grant", grantType)
+	if grantType == GRANT_PASSWORD {
+		log.Print("the password grant is deprecated: Salesforce disables it by default on new " +
+			"orgs and is retiring it. Prefer " + GRANT_CLIENT_CREDENTIALS + " or " + GRANT_JWT_BEARER)
+	}
+
+	// Each grant needs a different subset of the OAUTH_ variables, so they are validated per
+	// grant rather than unconditionally. In particular the client credentials grant needs no
+	// username: the run-as identity is designated on the app in Salesforce.
+	switch grantType {
+	case GRANT_JWT_BEARER:
+		if oauthJWTKey == "" {
+			return nil, errors.New("OAUTH_JWT_KEY not set")
 		}
-		bridge.oauthSecret = os.Getenv("OAUTH_SECRET")
-		if bridge.oauthSecret == "" {
-			return nil, errors.New("OAUTH_SECRET not set")
-		}
-	} else {
 		decodedString, err := base64.StdEncoding.DecodeString(oauthJWTKey)
 		if err != nil {
 			return nil, errors.New("OAUTH_JWT_KEY is not valid standard-encoding base64")
@@ -173,11 +228,30 @@ func newBridge() (*Bridge, error) {
 			return nil, errors.New("OAUTH_JWT_KEY failed to decode PKCS1 private key from PEM bytes")
 		}
 		bridge.oauthJWTKey = decodedX509
-	}
 
-	bridge.oauthUsername = os.Getenv("OAUTH_USERNAME")
-	if bridge.oauthUsername == "" {
-		return nil, errors.New("OAUTH_USERNAME not set")
+		bridge.oauthUsername = os.Getenv("OAUTH_USERNAME")
+		if bridge.oauthUsername == "" {
+			return nil, errors.New("OAUTH_USERNAME not set")
+		}
+	case GRANT_CLIENT_CREDENTIALS:
+		bridge.oauthSecret = os.Getenv("OAUTH_SECRET")
+		if bridge.oauthSecret == "" {
+			return nil, errors.New("OAUTH_SECRET not set")
+		}
+	case GRANT_PASSWORD:
+		bridge.oauthPassword = os.Getenv("OAUTH_PASSWORD")
+		if bridge.oauthPassword == "" {
+			return nil, errors.New("OAUTH_PASSWORD not set")
+		}
+		bridge.oauthSecret = os.Getenv("OAUTH_SECRET")
+		if bridge.oauthSecret == "" {
+			return nil, errors.New("OAUTH_SECRET not set")
+		}
+
+		bridge.oauthUsername = os.Getenv("OAUTH_USERNAME")
+		if bridge.oauthUsername == "" {
+			return nil, errors.New("OAUTH_USERNAME not set")
+		}
 	}
 
 	httpTimeoutDuration := HTTP_TIMEOUT
@@ -269,19 +343,30 @@ func (bridge *Bridge) makeJWT() (*string, error) {
 
 func (bridge *Bridge) authorizeSalesforce() (error, bool) {
 	query := url.Values{}
-	if bridge.oauthJWTKey != nil {
+	switch bridge.oauthGrantType {
+	case GRANT_JWT_BEARER:
 		jwt, err := bridge.makeJWT()
 		if err != nil {
 			return err, true
 		}
 		query.Add("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
 		query.Add("assertion", *jwt)
-	} else {
+	case GRANT_CLIENT_CREDENTIALS:
+		// No username: the app in Salesforce designates the run-as identity, so the
+		// daemon holds no user credential at all.
+		query.Add("grant_type", "client_credentials")
+		query.Add("client_id", bridge.oauthId)
+		query.Add("client_secret", bridge.oauthSecret)
+	case GRANT_PASSWORD:
 		query.Add("grant_type", "password")
 		query.Add("client_id", bridge.oauthId)
 		query.Add("client_secret", bridge.oauthSecret)
 		query.Add("username", bridge.oauthUsername)
 		query.Add("password", bridge.oauthPassword)
+	default:
+		// newBridge resolves the grant to one of the constants above and refuses to start
+		// otherwise, so reaching here means the two have drifted apart.
+		return errors.New("unsupported OAuth grant type '" + bridge.oauthGrantType + "'"), true
 	}
 
 	authRequest, err := http.NewRequest("POST", bridge.oauthURI.String(), strings.NewReader(query.Encode()))

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -123,6 +123,22 @@ func parseDurationFromEnv(name string, fallback time.Duration) time.Duration {
 	return parsed
 }
 
+// tokenEndpointFrom builds an org's token endpoint from its Apex REST URL.
+//
+// The client credentials grant is only accepted on the org's own domain; the shared
+// login host answers "invalid_grant: request not supported on this domain". Since
+// SALESFORCE_URL already names the right host, the endpoint is derived from it rather
+// than being made the operator's problem to discover.
+func tokenEndpointFrom(salesforceURL string) (string, error) {
+	parsed, err := url.Parse(salesforceURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", errors.New("cannot derive a token endpoint from SALESFORCE_URL '" +
+			salesforceURL + "'; set OAUTH_URI explicitly")
+	}
+
+	return parsed.Scheme + "://" + parsed.Host + "/services/oauth2/token", nil
+}
+
 // resolveGrantType decides which OAuth flow to use.
 //
 // An explicit OAUTH_GRANT_TYPE always wins. When it is unset the flow is inferred from the
@@ -180,9 +196,28 @@ func newBridge() (*Bridge, error) {
 		return nil, errors.New("OAUTH_ID not set")
 	}
 
+	oauthJWTKey := os.Getenv("OAUTH_JWT_KEY")
+
+	grantType, err := resolveGrantType(oauthJWTKey)
+	if err != nil {
+		return nil, err
+	}
+	bridge.oauthGrantType = grantType
+
+	// The token endpoint depends on the grant, so it is resolved after it.
 	oauthURIString := os.Getenv("OAUTH_URI")
 	if oauthURIString == "" {
-		oauthURIString = OAUTH_URI
+		if grantType == GRANT_CLIENT_CREDENTIALS {
+			derived, err := tokenEndpointFrom(bridge.salesforceURL)
+			if err != nil {
+				return nil, err
+			}
+			oauthURIString = derived
+			log.Printf("OAUTH_URI is not set; using %s derived from SALESFORCE_URL, because the "+
+				"client credentials grant is not accepted on the shared login host", derived)
+		} else {
+			oauthURIString = OAUTH_URI
+		}
 	}
 
 	oauthURI, err := url.Parse(oauthURIString)
@@ -191,13 +226,16 @@ func newBridge() (*Bridge, error) {
 	}
 	bridge.oauthURI = *oauthURI
 
-	oauthJWTKey := os.Getenv("OAUTH_JWT_KEY")
-
-	grantType, err := resolveGrantType(oauthJWTKey)
-	if err != nil {
-		return nil, err
+	// A configured login host cannot work for this grant, and Salesforce's rejection --
+	// "request not supported on this domain" -- does not point at the cause.
+	if grantType == GRANT_CLIENT_CREDENTIALS {
+		host := strings.ToLower(bridge.oauthURI.Host)
+		if host == "login.salesforce.com" || host == "test.salesforce.com" {
+			log.Printf("OAUTH_URI points at %s, which rejects the client credentials grant; "+
+				"use the org's own domain, such as %s", host,
+				"https://MyDomainName.my.salesforce.com/services/oauth2/token")
+		}
 	}
-	bridge.oauthGrantType = grantType
 	log.Printf("authenticating to Salesforce with the %s grant", grantType)
 	if grantType == GRANT_PASSWORD {
 		log.Print("the password grant is deprecated: Salesforce disables it by default on new " +

--- a/bridge/main_test.go
+++ b/bridge/main_test.go
@@ -3,6 +3,11 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"io/ioutil"
 	"log"
 	"net"
@@ -923,4 +928,105 @@ func TestAuthorizeSalesforcePostsTheRightForm(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTokenEndpointFrom(t *testing.T) {
+	tests := []struct {
+		name          string
+		salesforceURL string
+		want          string
+		wantErr       bool
+	}{
+		{
+			name:          "apex rest url",
+			salesforceURL: "https://example-dev-ed.develop.my.salesforce.com/services/apexrest/",
+			want:          "https://example-dev-ed.develop.my.salesforce.com/services/oauth2/token",
+		},
+		{
+			name:          "no trailing slash",
+			salesforceURL: "https://example.my.salesforce.com/services/apexrest",
+			want:          "https://example.my.salesforce.com/services/oauth2/token",
+		},
+		{name: "empty is an error", salesforceURL: "", wantErr: true},
+		{name: "no scheme is an error", salesforceURL: "example.my.salesforce.com/services/apexrest/", wantErr: true},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got, err := tokenEndpointFrom(test.salesforceURL)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %q, got %q", test.salesforceURL, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("tokenEndpointFrom returned unexpected error: %v", err)
+			}
+			if got != test.want {
+				t.Errorf("endpoint = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestClientCredentialsDerivesItsTokenEndpoint covers the failure this defends against: the
+// shared login host rejects the client credentials grant with "request not supported on this
+// domain", so leaving OAUTH_URI at its default would break every deployment using this grant.
+// Verified against the live org before the derivation existed.
+func TestClientCredentialsDerivesItsTokenEndpoint(t *testing.T) {
+	setMinimalBridgeEnv(t)
+	setEnv(t, "OAUTH_GRANT_TYPE", GRANT_CLIENT_CREDENTIALS)
+	unsetEnv(t, "OAUTH_URI")
+
+	bridge, err := newBridge()
+	if err != nil {
+		t.Fatalf("newBridge returned unexpected error: %v", err)
+	}
+
+	want := "https://example.invalid/services/oauth2/token"
+	if got := bridge.oauthURI.String(); got != want {
+		t.Errorf("token endpoint = %q, want %q", got, want)
+	}
+}
+
+// The other grants are accepted on the shared login host, so their default must not change.
+func TestOtherGrantsKeepTheDefaultTokenEndpoint(t *testing.T) {
+	for _, grant := range []string{GRANT_JWT_BEARER, GRANT_PASSWORD} {
+		grant := grant
+		t.Run(grant, func(t *testing.T) {
+			setMinimalBridgeEnv(t)
+			setEnv(t, "OAUTH_GRANT_TYPE", grant)
+			unsetEnv(t, "OAUTH_URI")
+			if grant == GRANT_JWT_BEARER {
+				setEnv(t, "OAUTH_JWT_KEY", testJWTKeyBase64(t))
+			}
+
+			bridge, err := newBridge()
+			if err != nil {
+				t.Fatalf("newBridge returned unexpected error: %v", err)
+			}
+			if got := bridge.oauthURI.String(); got != OAUTH_URI {
+				t.Errorf("token endpoint = %q, want the default %q", got, OAUTH_URI)
+			}
+		})
+	}
+}
+
+// testJWTKeyBase64 produces an OAUTH_JWT_KEY the bridge will accept: a PKCS#1 key in a PEM
+// block labelled "RSA PRIVATE KEY", base64 encoded. A short key keeps the test fast; nothing
+// here signs anything that Salesforce verifies.
+func testJWTKeyBase64(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("failed generating a test RSA key: %v", err)
+	}
+	encoded := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	return base64.StdEncoding.EncodeToString(encoded)
 }

--- a/bridge/main_test.go
+++ b/bridge/main_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -199,7 +201,7 @@ func setMinimalBridgeEnv(t *testing.T) {
 	setEnv(t, "OAUTH_USERNAME", "test@example.invalid")
 	setEnv(t, "OAUTH_PASSWORD", "test-password")
 	setEnv(t, "OAUTH_SECRET", "test-secret")
-	for _, name := range []string{"OAUTH_JWT_KEY", "OAUTH_URI", "HTTP_TIMEOUT", "LD_BASE_URI", "LD_EVENTS_URI"} {
+	for _, name := range []string{"OAUTH_JWT_KEY", "OAUTH_URI", "HTTP_TIMEOUT", "LD_BASE_URI", "LD_EVENTS_URI", "OAUTH_GRANT_TYPE"} {
 		unsetEnv(t, name)
 	}
 }
@@ -734,5 +736,191 @@ func TestEventLoopReusesConnectionsOnPollError(t *testing.T) {
 		t.Errorf("opened %d connections for %d failed event drains (allowed %d); "+
 			"the error response body is never read, so no connection can be reused",
 			connections, served, allowedConnections)
+	}
+}
+
+func TestResolveGrantType(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		setEnvVar  bool
+		jwtKey     string
+		want       string
+		wantErr    bool
+	}{
+		// Unset falls back to inference, which is how the bridge behaved before
+		// OAUTH_GRANT_TYPE existed. Every deployment predating it keeps working.
+		{name: "unset with a jwt key infers jwt bearer", jwtKey: "not-empty", want: GRANT_JWT_BEARER},
+		{name: "unset without a jwt key infers password", want: GRANT_PASSWORD},
+
+		{name: "explicit jwt bearer", configured: GRANT_JWT_BEARER, setEnvVar: true, want: GRANT_JWT_BEARER},
+		{name: "explicit client credentials", configured: GRANT_CLIENT_CREDENTIALS, setEnvVar: true, want: GRANT_CLIENT_CREDENTIALS},
+		{name: "explicit password", configured: GRANT_PASSWORD, setEnvVar: true, want: GRANT_PASSWORD},
+
+		// Client credentials cannot be inferred: its credentials are a subset of the
+		// password grant's, so an explicit choice must override a present JWT key.
+		{
+			name:       "explicit choice overrides a present jwt key",
+			configured: GRANT_CLIENT_CREDENTIALS,
+			setEnvVar:  true,
+			jwtKey:     "not-empty",
+			want:       GRANT_CLIENT_CREDENTIALS,
+		},
+
+		{name: "case and surrounding whitespace are tolerated", configured: "  Client-Credentials  ", setEnvVar: true, want: GRANT_CLIENT_CREDENTIALS},
+
+		// A typo must stop startup rather than silently selecting a different flow.
+		{name: "unrecognized value is an error", configured: "client_credentials", setEnvVar: true, wantErr: true},
+		{name: "nonsense is an error", configured: "oauth", setEnvVar: true, wantErr: true},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			if test.setEnvVar {
+				setEnv(t, "OAUTH_GRANT_TYPE", test.configured)
+			} else {
+				unsetEnv(t, "OAUTH_GRANT_TYPE")
+			}
+
+			got, err := resolveGrantType(test.jwtKey)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %q, got grant %q", test.configured, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveGrantType returned unexpected error: %v", err)
+			}
+			if got != test.want {
+				t.Errorf("grant = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestClientCredentialsNeedsNoUsername is the point of the whole change: the run-as identity
+// lives on the app in Salesforce, so the daemon holds no user credential. If this starts
+// failing, the per-grant validation has regressed into requiring a username again.
+func TestClientCredentialsNeedsNoUsername(t *testing.T) {
+	setMinimalBridgeEnv(t)
+	setEnv(t, "OAUTH_GRANT_TYPE", GRANT_CLIENT_CREDENTIALS)
+	unsetEnv(t, "OAUTH_USERNAME")
+	unsetEnv(t, "OAUTH_PASSWORD")
+
+	bridge, err := newBridge()
+	if err != nil {
+		t.Fatalf("newBridge rejected a valid client credentials configuration: %v", err)
+	}
+	if bridge.oauthGrantType != GRANT_CLIENT_CREDENTIALS {
+		t.Errorf("grant = %q, want %q", bridge.oauthGrantType, GRANT_CLIENT_CREDENTIALS)
+	}
+}
+
+func TestGrantValidationIsPerGrant(t *testing.T) {
+	tests := []struct {
+		name    string
+		grant   string
+		unset   []string
+		wantErr bool
+	}{
+		{name: "client credentials without a secret", grant: GRANT_CLIENT_CREDENTIALS, unset: []string{"OAUTH_SECRET"}, wantErr: true},
+		{name: "client credentials without a password is fine", grant: GRANT_CLIENT_CREDENTIALS, unset: []string{"OAUTH_PASSWORD"}},
+		{name: "jwt bearer without a key", grant: GRANT_JWT_BEARER, unset: []string{"OAUTH_JWT_KEY"}, wantErr: true},
+		{name: "password without a username", grant: GRANT_PASSWORD, unset: []string{"OAUTH_USERNAME"}, wantErr: true},
+		{name: "password without a password", grant: GRANT_PASSWORD, unset: []string{"OAUTH_PASSWORD"}, wantErr: true},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			setMinimalBridgeEnv(t)
+			setEnv(t, "OAUTH_GRANT_TYPE", test.grant)
+			for _, name := range test.unset {
+				unsetEnv(t, name)
+			}
+
+			_, err := newBridge()
+			if test.wantErr && err == nil {
+				t.Error("expected newBridge to reject the configuration, it succeeded")
+			}
+			if !test.wantErr && err != nil {
+				t.Errorf("newBridge returned unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestAuthorizeSalesforcePostsTheRightForm asserts the wire contract for each grant, since
+// that is what Salesforce actually validates. The client credentials case additionally
+// asserts the absence of username and password: sending a user credential on a grant that
+// does not take one is the mistake worth catching.
+func TestAuthorizeSalesforcePostsTheRightForm(t *testing.T) {
+	tests := []struct {
+		name        string
+		grant       string
+		wantGrant   string
+		wantPresent []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "client credentials",
+			grant:       GRANT_CLIENT_CREDENTIALS,
+			wantGrant:   "client_credentials",
+			wantPresent: []string{"client_id", "client_secret"},
+			wantAbsent:  []string{"username", "password", "assertion"},
+		},
+		{
+			name:        "password",
+			grant:       GRANT_PASSWORD,
+			wantGrant:   "password",
+			wantPresent: []string{"client_id", "client_secret", "username", "password"},
+			wantAbsent:  []string{"assertion"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			var posted url.Values
+
+			tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := ioutil.ReadAll(r.Body)
+				posted, _ = url.ParseQuery(string(body))
+				_, _ = w.Write([]byte(`{"access_token":"test-token"}`))
+			}))
+			defer tokenServer.Close()
+
+			setMinimalBridgeEnv(t)
+			setEnv(t, "OAUTH_GRANT_TYPE", test.grant)
+			setEnv(t, "OAUTH_URI", tokenServer.URL)
+
+			bridge, err := newBridge()
+			if err != nil {
+				t.Fatalf("newBridge returned unexpected error: %v", err)
+			}
+
+			if err, _ := bridge.authorizeSalesforce(); err != nil {
+				t.Fatalf("authorizeSalesforce returned unexpected error: %v", err)
+			}
+
+			if got := posted.Get("grant_type"); got != test.wantGrant {
+				t.Errorf("grant_type = %q, want %q", got, test.wantGrant)
+			}
+			for _, name := range test.wantPresent {
+				if posted.Get(name) == "" {
+					t.Errorf("%s missing from the token request", name)
+				}
+			}
+			for _, name := range test.wantAbsent {
+				if _, ok := posted[name]; ok {
+					t.Errorf("%s was sent on the %s grant and should not have been", name, test.grant)
+				}
+			}
+			if bridge.oauthCurrentToken != "test-token" {
+				t.Errorf("token = %q, want %q", bridge.oauthCurrentToken, "test-token")
+			}
+		})
 	}
 }


### PR DESCRIPTION
The bridge could authenticate to Salesforce with the JWT bearer or the
username-password flow, and nothing else. Orgs whose connected app or
External Client App is configured for the client credentials flow could not
use it at all; this was requested externally as apex-server-sdk issue 55,
where the reporter had patched their own copy locally.

Client credentials is the flow to prefer for a new deployment. It needs no
certificate to generate, upload or rotate, and no username -- the run-as
identity is designated on the app in Salesforce, so the daemon holds no user
credential. It also sends no time-bound assertion, which matters more than it
sounds: makeJWT stamps an expiry 120 seconds out with no tolerance, so a host
whose clock has drifted past two minutes fails every JWT authentication
attempt. There is no equivalent failure mode here.

The grant type is now an explicit choice via OAUTH_GRANT_TYPE, logged at
startup. Previously the flow was whichever branch the environment happened to
fall into, keyed on whether OAUTH_JWT_KEY was set. A third flow makes that
untenable: client credentials takes OAUTH_ID and OAUTH_SECRET, a subset of
what the password flow takes, so it cannot be distinguished by inspection and
has to be requested. A typo in the variable now stops startup rather than
silently selecting a different flow.

Inference is retained when OAUTH_GRANT_TYPE is unset, so every existing
deployment keeps working with no change. Credential validation moved from a
single unconditional block to per-grant, which is what lets client credentials
start without OAUTH_USERNAME -- previously required by every configuration.

Selecting the password flow now logs a deprecation warning. Salesforce
disables it by default on new orgs and is retiring it. Removal belongs in a
future major.

Tests assert the posted form per grant rather than only the resolved
configuration, since the form is what Salesforce validates. The client
credentials case asserts the absence of username and password too: sending a
user credential on a grant that does not accept one is the mistake worth
catching. Verified against go1.15.15, the version CI pins.

Refs SDK-2956.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **Salesforce OAuth client credentials** as a third authentication path for the bridge, alongside JWT bearer and password (password is now documented and warned as deprecated).
> 
> Operators choose the flow with **`OAUTH_GRANT_TYPE`** (`client-credentials`, `jwt-bearer`, or `password`); the resolved grant is logged at startup. When unset, behavior is unchanged: JWT bearer if `OAUTH_JWT_KEY` is set, otherwise password. Client credentials must be set explicitly because it shares `OAUTH_ID` / `OAUTH_SECRET` with the password flow.
> 
> **Credential checks are per grant**, so client credentials can start without `OAUTH_USERNAME` or `OAUTH_PASSWORD`. Token requests use the correct form per grant (`client_credentials` with id/secret only, etc.).
> 
> For client credentials, **`OAUTH_URI` defaults are org-specific**: if unset, the token URL is derived from `SALESFORCE_URL` (shared `login.salesforce.com` / `test.salesforce.com` hosts are rejected for this grant), with logging when derived or when a login host is configured anyway.
> 
> README expands authentication guidance; tests cover grant resolution, validation, posted token forms, and endpoint derivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdf66b1ed71ddfea757e0ec5dff7189b4a55a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->